### PR TITLE
Remove baseclass names from subclass entries.

### DIFF
--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -158,7 +158,9 @@ class XMLCombiner(object):
             if args.subtype_format != 'none':  # useable or reference both want entries
                 reference_class = et.fromstring('<class name="{0}">\n\t</class>'.format(name))
                 if args.subtype_format == 'usable':  # skip baseclass info for 'reference'
-                    reference_class.extend(list(items['baseclass'][base_name]))
+                    base_class = copy.deepcopy(items['baseclass'][base_name])
+                    base_class.remove(base_class.find('name'))
+                    reference_class.extend(list(base_class))
                 reference_class.extend(list(element))
                 items['class'][name] = reference_class
 


### PR DESCRIPTION
This prevents such sections as being marked as duplicates.

The baseclass `<name>` tag in the subclass `<class>` elements caused subclasses to be marked as duplicates are excluded from the compendium.

This happens when using `--subtype-format usable`.