### PR TITLE
Update classes for asi

### DIFF
--- a/Character/Classes/Artificer/Artificer.xml
+++ b/Character/Classes/Artificer/Artificer.xml
@@ -3,7 +3,11 @@
 	<baseclass>
 		<name>Artificer</name>
 		<hd>8</hd>
-		<proficiency>Constitution, Intelligence</proficiency>
+		<proficiency>Constitution, Intelligence, Arcana, Deception, History, Investigation, Medicine, Nature, Religion, Sleight of Hand</proficiency>
+		<numSkills>3</numSkills>
+<armor>light armor, medium armor</armor>
+<weapons>simple weapons</weapons>
+<tools>thieves' tools + 2 other of your choice</tools>
 		<spellAbility>Intelligence</spellAbility>
 		<autolevel level="1">
 			<slots>0,0,0,0,0,0</slots>
@@ -147,13 +151,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature optional="YES">
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text/>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 			<feature>
 				<name>Infuse Magic</name>
 				<text>Starting at 4th level, you gain the ability to channel your artificer spells into objects for later use. When you cast an artificer spell with a casting time of 1 action, you can increase its casting time to 1 minute. If you do so and hold a nonmagical item throughout the casting, you expend a spell slot, but none of the spell's effect's occur. Instead, the spell transfers into that item for later use if the item doesn't already contain a spell from this feature.</text>
@@ -195,12 +193,7 @@
 				<text>If the servant is killed, it can be returned to life via normal means, such as with the revivify spell. In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest. If the servant is beyond recovery, you can build a new one with one week of work (eight hours each day) and 1,000 gp of raw materials.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<!-- Archetype features -->
@@ -218,12 +211,7 @@
 				<text>10th Level: bag of beans, chime of opening, decanter of endless water, eyes of minute seeing, folding boat, Heward's handy haversack</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<!-- Archetype features -->
@@ -246,22 +234,12 @@
 				<text>15th Level: boots of striding and springing, bracers of archery, brooch of shielding, broom of flying, hat of disguise, slippers of spider climbing</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="18">
-			<feature>
-				<name>Ability Score Improvement  </name>
-				<text>When you reach 18th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="18" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Barbarian/Barbarian.xml
+++ b/Character/Classes/Barbarian/Barbarian.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Barbarian</name>
 		<hd>12</hd>
-		<proficiency>Strength, Constitution</proficiency>
+		<proficiency>Strength, Constitution, Animal Handling, Athletics, Intimidation, Nature, Perception, Survival</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor, medium armor, shields</armor>
+<weapons>simple weapons, martial weapons</weapons>
+<tools>none</tools>
+<wealth>2d4x10</wealth>
 		<autolevel level="1">
 			<feature>
 				<name>Starting Proficiencies</name>
@@ -65,12 +70,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -97,12 +97,7 @@
 				<text>	Additionally, if you are surprised at the beginning of combat and aren't incapacitated, you can act normally on your first turn, but only if you enter your rage before doing anything else on that turn.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<feature>
@@ -125,12 +120,7 @@
 				<text>	Each time you use this feature after the first, the DC increases by 5. When you finish a short or long rest, the DC resets to 10.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 			<feature>
 				<name>Increased Rages</name>
 				<text>You may now rage 5 times before a long rest</text>
@@ -151,12 +141,7 @@
 				<text>Beginning at 15th level, your rage is so fierce that it ends early only if you fall unconscious or if you choose to end it.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 			<feature>
 				<name>Increased Rage Damage</name>
 				<text>You now have a +4 bonus to melee damage rolls while raging.</text>
@@ -178,12 +163,7 @@
 				<text>Beginning at 18th level, if your total for a Strength check is less than your Strength score, you can use that score in place of the total.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Bard/Bard.xml
+++ b/Character/Classes/Bard/Bard.xml
@@ -4,6 +4,11 @@
 		<name>Bard</name>
 		<hd>8</hd>
 		<proficiency>Dexterity, Charisma</proficiency>
+		<nunSkills>3</nunSkills>
+		<armor>light armor</armor>
+<weapons>simple weapons, hand crossbows, longswords, rapiers, shortswords</weapons>
+<tools>three musical instruments of your choice</tools>
+<wealth>5d4x10</wealth>
 		<spellAbility>Charisma</spellAbility>
 		<autolevel level="1">
 			<slots>2,2,0,0,0,0,0,0,0,0</slots>
@@ -148,12 +153,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -172,12 +172,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<feature>
@@ -201,12 +196,7 @@
 				<text>	You learn two additional spells from any class at 14th level and again at 18th level.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="13">
 			<feature>
@@ -228,12 +218,7 @@
 				<text>At 15th level, your Bardic Inspiration die changes to a d12.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -248,12 +233,7 @@
 				<text>	The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Cleric/Cleric.xml
+++ b/Character/Classes/Cleric/Cleric.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Cleric</name>
 		<hd>8</hd>
-		<proficiency>Wisdom, Charisma</proficiency>
+		<proficiency>Wisdom, Charisma, History, Insight, Medicine, Persuasion, Religion</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor, medium armor, shields</armor>
+<weapons>simple weapons</weapons>
+<tools>none</tools>
+<wealth>5d4x10</wealth>
 		<spellAbility>Wisdom</spellAbility>
 		<autolevel level="1">
 			<slots>3,2,0,0,0,0,0,0,0,0</slots>
@@ -137,12 +142,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -157,12 +157,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 			<feature>
 				<name>Destroy Undead (CR 1)</name>
 				<text>Starting at 8th level, when an undead of CR 1 or lower fails its saving throw against your Turn Undead feature, the creature is instantly destroyed.</text>
@@ -183,12 +178,7 @@
 				<text>Starting at 11th level, when an undead of CR 2 or lower fails its saving throw against your Turn Undead feature, the creature is instantly destroyed.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<feature>
@@ -196,12 +186,7 @@
 				<text>Starting at 14th level, when an undead of CR 3 or lower fails its saving throw against your Turn Undead feature, the creature is instantly destroyed.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -216,12 +201,7 @@
 				<text>Beginning at 18th level, you can use your Channel Divinity three times between rests.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Druid/Druid.xml
+++ b/Character/Classes/Druid/Druid.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Druid</name>
 		<hd>8</hd>
-		<proficiency>Intelligence, Wisdom</proficiency>
+		<proficiency>Intelligence, Wisdom, Arcana, Animal Handling, Insight, Medicine, Nature, Perception, Religion, Survival</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor, medium armor, shields (druids will not wear armor or use shields made of metal)</armor>
+<weapons>clubs, daggers, darts, javelins, maces, quarterstaffs, scimitars, sickles, slings, spears</weapons>
+<tools>herbalism kit</tools>
+<wealth>2d4x10</wealth>
 		<spellAbility>Wisdom</spellAbility>
 		<autolevel level="1">
 			<slots>2,2,0,0,0,0,0,0,0,0</slots>
@@ -141,42 +146,22 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="6">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="10">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="18">
 			<feature>
@@ -188,12 +173,7 @@
 				<text>Beginning at 18th level, you can cast many of your druid spells in any shape you assume using Wild Shape. You can perform the somatic and verbal components of a druid spell while in a beast shape, but you aren't able to provide material components.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Fighter/Fighter (Champion).xml
+++ b/Character/Classes/Fighter/Fighter (Champion).xml
@@ -24,6 +24,35 @@
 				<name>Champion: Additional Fighting Style</name>
 				<text>At 10th level, you can choose a second option from the Fighting Style class feature.</text>
 			</feature>
+			<feature optional="YES">
+				<name>Fighting Style: Archery</name>
+				<text>You gain a +2 bonus to attack rolls you make with ranged weapons.</text>
+				<special>Fighting Style: Archery</special>
+			</feature>
+			<feature optional="YES">
+				<name>Fighting Style: Defense</name>
+				<text>While you are wearing armor, you gain a +1 bonus to AC.</text>
+				<special>Fighting Style: Defense</special>
+			</feature>
+			<feature optional="YES">
+				<name>Fighting Style: Dueling</name>
+				<text>When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.</text>
+				<special>Fighting Style: Dueling</special>
+			</feature>
+			<feature optional="YES">
+				<name>Fighting Style: Great Weapon Fighting</name>
+				<text>When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2. The weapon must have the two-handed or versatile property for you to gain this benefit.
+				</text>
+			</feature>
+			<feature optional="YES">
+				<name>Fighting Style: Protection</name>
+				<text>When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Fighting Style: Two-Weapon Fighting</name>
+				<text>When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.</text>
+				<special>Fighting Style: Two-Weapon Fighting</special>
+			</feature>
 		</autolevel>
 		<autolevel level="15">
 			<feature optional="YES">

--- a/Character/Classes/Fighter/Fighter.xml
+++ b/Character/Classes/Fighter/Fighter.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Fighter</name>
 		<hd>10</hd>
-		<proficiency>Strength, Constitution</proficiency>
+		<proficiency>Strength, Constitution, Acrobatics, Animal Handling, Athletics, History, Insight, Intimidation, Perception, Survival</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor, medium armor, heavy armor, shields</armor>
+<weapons>simple weapons, martial weapons</weapons>
+<tools>none</tools>
+<wealth>5d4x10</wealth>
 		<autolevel level="1">
 			<feature>
 				<name>Starting Proficiencies</name>
@@ -12,8 +17,7 @@
 				<text>Armor: light armor, medium armor, heavy armor, shields</text>
 				<text>Weapons: simple weapons, martial weapons</text>
 				<text>Tools: none</text>
-				<text>Skills: Choose two skills from Acrobatics, Animal Handling, Athletics, History, Insight, Intimidation, Perception, and Survival
-				</text>
+				<text>Skills: Choose two skills from Acrobatics, Animal Handling, Athletics, History, Insight, Intimidation, Perception, and Survival</text>
 			</feature>
 			<feature>
 				<name>Starting Equipment</name>
@@ -82,11 +86,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -96,21 +95,11 @@
 			</feature>
 		</autolevel>
 		<autolevel level="6">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 6th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature. </text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="7">
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="9">
 			<feature>
@@ -129,11 +118,6 @@
 			</feature>
 		</autolevel>
 		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="13">
 			<feature>
@@ -142,21 +126,11 @@
 			</feature>
 		</autolevel>
 		<autolevel level="14">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 14th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature. </text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="15">
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.
-				</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 		<autolevel level="17">
@@ -173,11 +147,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Fighter/Fighter.xml
+++ b/Character/Classes/Fighter/Fighter.xml
@@ -85,7 +85,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -94,12 +94,12 @@
 				<text>	The number of attacks increases to three when you reach 11th level in this class and to four when you reach 20th level in this class.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="6">
+		<autolevel level="6" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="7">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<feature>
@@ -117,7 +117,7 @@
 				<text>At 11th level, you can attack three times whenever you take the Attack action on your turn.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="13">
 			<feature>
@@ -125,13 +125,12 @@
 				<text>At 13th level, you can use Indomitable twice between long rests.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="14">
+		<autolevel level="14" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="15">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -146,7 +145,7 @@
 		<autolevel level="18">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="19">
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Monk/Monk.xml
+++ b/Character/Classes/Monk/Monk.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Monk</name>
 		<hd>8</hd>
-		<proficiency>Strength, Dexterity</proficiency>
+		<proficiency>Strength, Dexterity, Acrobatics, Athletics, History, Insight, Religion, Stealth</proficiency>
+		<numSkills>2</numSkills>
+		<armor>none</armor>
+<weapons>simple weapons, shortswords</weapons>
+<tools>any one type of artisan's tools or any one musical instrument of your choice</tools>
+<wealth>5d4</wealth>
 		<spellAbility>Wisdom</spellAbility>
 		<autolevel level="1">
 			<feature>
@@ -84,12 +89,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 			<feature>
 				<name>Slow Fall</name>
 				<text>Beginning at 4th level, you can use your reaction when you fall to reduce any falling damage you take by an amount equal to five times your monk level.</text>
@@ -131,12 +131,7 @@
 				<text>At 7th level, your instinctive agility lets you dodge out of the way of certain area effects, such as a blue dragon's lightning breath or a fireball spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<feature>
@@ -162,12 +157,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="13">
 			<feature>
@@ -194,12 +184,7 @@
 				<text>At 15th level, your ki sustains you so that you suffer none of the frailty of old age, and you can't be aged magically. You can still die of old age, however. In addition, you no longer need food or water.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -220,12 +205,7 @@
 				<modifier category="bonus">speed +5</modifier>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Mystic/Mystic.xml
+++ b/Character/Classes/Mystic/Mystic.xml
@@ -3,7 +3,12 @@
 	<baseclass UA="The Mystic Class">
 		<name>Mystic (UA)</name>
 		<hd>8</hd>
-		<proficiency>Intelligence, Wisdom</proficiency>
+		<proficiency>Intelligence, Wisdom, Arcana, History, Insight, Medicine, Nature, Perception, Religion</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor</armor>
+<weapons>simple weapons</weapons>
+<tools>none</tools>
+<wealth>5d4x10</wealth>
 		<spellAbility>Intelligence</spellAbility>
 		<autolevel level="1">
 			<slots>1,1,4,2,0,0,0,0,0,0</slots>
@@ -334,12 +339,7 @@
 				<text>Starting at 3rd level, when a creature's resistance reduces the damage dealt by a psionic discipline of yours, you can spend 1 psi point to cause that use of the discipline to ignore the creature's resistance. You can't spend this point if doing so would increase the discipline's cost above your psi limit.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 			<feature>
 				<name>Strength of Mind</name>
 				<text>Even the simplest psionic technique requires a deep understanding of how psionic energy can augment mind and body. This understanding allows you to alter your defenses to better deal with threats.</text>
@@ -384,12 +384,7 @@
 				<text>	Whenever you gain a level in this class, you can replace one of the chosen wizard spells with a different wizard spell of 1st through 3rd level.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 			<feature>
 				<name>Potent Psionics (Order of the Awakened)</name>
 				<text>At 8th level, you gain the ability to infuse your weapon attacks with psychic energy. Once on each of your turns when you hit a creature with a weapon, you can deal an extra 1d8 psychic damage to that target. When you reach 14th level, this extra damage increases to 2d8.</text>
@@ -408,12 +403,7 @@
 				You have one use of this feature, and you regain any expended use of it with a long rest.
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="13">
 			<feature>
@@ -458,12 +448,7 @@
 				<text> You gain one additional use of the PsionicMastery feature at 13th, 15th, and 17th level.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -471,12 +456,7 @@
 				<text>You gain one additional use of the PsionicMastery feature at 13th, 15th, and 17th level.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="20">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM uses the optional Feats, you can instead take a feat.</text>
-			</feature>
+		<autolevel level="20" scoreImprovement="YES">
 			<feature>
 				<name>Psionic Body</name>
 				<text>At 20th level, your mastery of psionic power causes your mind to transcend the body. Your physical form is infused with psionic energy. You gain the following benefits:</text>

--- a/Character/Classes/Paladin/Paladin.xml
+++ b/Character/Classes/Paladin/Paladin.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Paladin</name>
 		<hd>10</hd>
-		<proficiency>Wisdom, Charisma</proficiency>
+		<proficiency>Wisdom, Charisma, Athletics, Insight, Intimidation, Medicine, Persuasion, Religion</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor, medium armor, heavy armor, shields</armor>
+<weapons>simple weapons, martial weapons</weapons>
+<tools>none</tools>
+<wealth>5d4x10</wealth>
 		<spellAbility>Charisma</spellAbility>
 		<autolevel level="1">
 			<slots>0,0,0,0,0,0</slots>
@@ -166,12 +171,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -189,12 +189,7 @@
 		<autolevel level="7">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="10">
 			<feature>
@@ -209,12 +204,7 @@
 				<text>By 11th level, you are so suffused with righteous might that all your melee weapon strikes carry divine power with them. Whenever you hit a creature with a melee weapon, the creature takes an extra 1d8 radiant damage. If you also use your Divine Smite with an attack, you add this damage to the extra damage of your Divine Smite.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<feature>
@@ -226,12 +216,7 @@
 		<autolevel level="15">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="18">
 			<feature>
@@ -239,12 +224,7 @@
 				<text>At 18th level, the range of your Aura of Protection increases to 30 feet.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<!-- Archetype features -->

--- a/Character/Classes/Ranger/Ranger Revised.xml
+++ b/Character/Classes/Ranger/Ranger Revised.xml
@@ -3,8 +3,13 @@
 	<baseclass UA="UA">
 		<name>Ranger (Revised)</name>
 		<hd>10</hd>
-		<proficiency>Strength, Dexterity</proficiency>
+		<proficiency>Strength, Dexterity, Animal Handling, Athletics, Insight, Investigation, Nature, Perception, Stealth, Survival</proficiency>
+		<numSkills>3</numSkills>
 		<spellAbility>Wisdom</spellAbility>
+<armor>light armor, medium armor, shields</armor>
+<weapons>simple weapons, martial weapons</weapons>
+<tools>none</tools>
+		<wealth>5d10x4</wealth>
 		<autolevel level="1">
 			<slots>0,0,0,0,0,0</slots>
 		</autolevel>
@@ -82,7 +87,7 @@
 				<text/>
 				<text>Alternatively, you may start with 5d10 x 4 gp and choose your own equipment.</text>
 				<text/>
-				<text>This class is from Unearthed Arcana: The Range, Revised, and as such may not be allowed in your game. Consult your DM before choosing this class.</text>
+				<text>This class is from Unearthed Arcana: The Ranger, Revised, and as such may not be allowed in your game. Consult your DM before choosing this class.</text>
 			</feature>
 			<feature>
 				<name>Favored Enemy</name>
@@ -188,12 +193,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<!-- Archetype features -->
@@ -208,12 +208,7 @@
 		<autolevel level="7">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 			<feature>
 				<name>Fleet of Foot</name>
 				<text>Beginning at 8th level, you can use the Dash action as a bonus action on your turn.</text>
@@ -230,12 +225,7 @@
 		<autolevel level="11">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<feature>
@@ -246,12 +236,7 @@
 		<autolevel level="15">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="18">
 			<feature>
@@ -260,12 +245,7 @@
 				<text>	You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn't hidden from you and you aren't blinded or deafened.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Ranger/Ranger.xml
+++ b/Character/Classes/Ranger/Ranger.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Ranger</name>
 		<hd>10</hd>
-		<proficiency>Strength, Dexterity</proficiency>
+		<proficiency>Strength, Dexterity, Animal Handling, Athletics, Insight, Investigation, Nature, Perception, Stealth, Survival</proficiency>
+		<numSkills>3</numSkills>
+		<armor>light armor, medium armor, shields</armor>
+<weapons>simple weapons, martial weapons</weapons>
+<tools>none</tools>
+<wealth>5d4x10</wealth>
 		<spellAbility>Wisdom</spellAbility>
 		<autolevel level="1">
 			<slots>0,0,0,0,0,0</slots>
@@ -162,11 +167,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -189,11 +189,6 @@
 		</autolevel>
 		<autolevel level="8">
 			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
-			<feature>
 				<name>Land's Stride</name>
 				<text>Starting at 8th level, moving through nonmagical difficult terrain costs you no extra movement. You can also pass through nonmagical plants without being slowed by them and without taking damage from them if they have thorns, spines, or a similar hazard.</text>
 				<text>	In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell.</text>
@@ -214,11 +209,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="14">
 			<feature>
@@ -234,11 +224,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="18">
 			<feature>
@@ -247,11 +232,6 @@
 			</feature>
 		</autolevel>
 		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Rogue/Rogue.xml
+++ b/Character/Classes/Rogue/Rogue.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Rogue</name>
 		<hd>8</hd>
-		<proficiency>Dexterity, Intelligence</proficiency>
+		<proficiency>Dexterity, Intelligence, Acrobatics, Athletics, Deception, Insight, Intimidation, Investigation, Perception, Performance, Persuasion, Sleight of Hand, Stealth</proficiency>
+		<numSkills>4</numSkills>
+		<armor>light armor</armor>
+<weapons>simple weapons, hand crossbows, longswords, rapiers, shortswords</weapons>
+<tools>thieves' tools</tools>
+<wealth>4d4x10</wealth>
 		<autolevel level="1">
 			<feature>
 				<name>Starting Proficiencies</name>
@@ -11,7 +16,7 @@
 				<text>Armor: light armor</text>
 				<text>Weapons: simple weapons, hand crossbows, longswords, rapiers, shortswords</text>
 				<text>Tools: thieves' tools</text>
-				<text>Skills: Choose four from Acrobatics, Athletics, Deception, Insight, Intimidation, Investigation, Perception, Performance. Persuasion, Sleight of Hand, and Stealth</text>
+				<text>Skills: Choose four from Acrobatics, Athletics, Deception, Insight, Intimidation, Investigation, Perception, Performance, Persuasion, Sleight of Hand, and Stealth</text>
 			</feature>
 			<feature>
 				<name>Starting Equipment</name>
@@ -56,12 +61,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -75,22 +75,12 @@
 				<text>Beginning at 7th level, you can nimbly dodge out of the way of certain area effects, such as a red dragon's fiery breath or an ice storm spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="10">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 10th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="10" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="11">
 			<feature>
@@ -98,12 +88,7 @@
 				<text>By 11th level, you have refined your chosen skills until they approach perfection. Whenever you make an ability check that lets you add your proficiency bonus, you can treat a d20 roll of 9 or lower as a 10.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="13">
 			<!-- Archetype features -->
@@ -120,12 +105,7 @@
 				<text>By 15th level, you have acquired greater mental strength. You gain proficiency in Wisdom saving throws.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<!-- Archetype features -->
@@ -136,12 +116,7 @@
 				<text>Beginning at 18th level, you are so evasive that attackers rarely gain the upper hand against you. No attack roll has advantage against you while you aren't incapacitated.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Sorcerer/Sorcerer.xml
+++ b/Character/Classes/Sorcerer/Sorcerer.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Sorcerer</name>
 		<hd>6</hd>
-		<proficiency>Constitution, Charisma</proficiency>
+		<proficiency>Constitution, Charisma, Arcana, Deception, Insight, Intimidation, Persuasion, Religion</proficiency>
+		<numSkills>2</numSkills>
+		<armor>none</armor>
+<weapons>daggers, darts, slings, quarterstaffs, light crossbows</weapons>
+<tools>none</tools>
+<wealth>3d4x10</wealth>
 		<spellAbility>Charisma</spellAbility>
 		<autolevel level="1">
 			<slots>4,2,0,0,0,0,0,0,0,0</slots>
@@ -177,22 +182,12 @@
 				<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="6">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="10">
 			<feature>
@@ -234,22 +229,12 @@
 				<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -294,12 +279,7 @@
 		<autolevel level="18">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Warlock/Warlock.xml
+++ b/Character/Classes/Warlock/Warlock.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Warlock</name>
 		<hd>8</hd>
-		<proficiency>Wisdom, Charisma</proficiency>
+		<proficiency>Wisdom, Charisma, Arcana, Deception, History, Intimidation, Investigation, Nature, Religion</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor</armor>
+<weapons>simple weapons</weapons>
+<tools>none</tools>
+<wealth>4d4x10</wealth>
 		<spellAbility>Charisma</spellAbility>
 		<autolevel level="1">
 			<slots>2,1,0,0,0,0,0,0,0,0</slots>
@@ -143,12 +148,7 @@
 				<text>Your patron gives you a grimoire called a Book of Shadows. When you gain this feature, choose three cantrips from any class's spell list. The cantrips do not need to be from the same spell list. While the book is on your person, you can cast those cantrips at will. They don't count against your number of cantrips known. Any cantrip you cast with this feature is considered a warlock cantrip for you. If you lose your Book of Shadows, you can perform a 1-hour ceremony to receive a replacement from your patron. This ceremony can be performed during a short or long rest, and it destroys the previous book. The book turns to ash when you die.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -165,12 +165,7 @@
 				<text>You learn an additional eldritch invocation</text>
 			</feature>
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="9">
 			<feature>
@@ -189,12 +184,7 @@
 				<text>	At higher levels, you gain more warlock spells of your choice that can be cast in this way: one 7th-level spell at 13th level, one 8th-level spell at 15th level, and one 9th-level spell at 17th level. You regain all uses of your Mystic Arcanum when you finish a long rest.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 			<feature>
 				<name>Eldritch Invocation</name>
 				<text>You learn an additional eldritch invocation</text>
@@ -221,12 +211,7 @@
 				<text>	You can cast your arcanum spell once without expending a spell slot. You must finish a long rest before you can do so again.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -241,12 +226,7 @@
 				<text>You learn an additional eldritch invocation</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Character/Classes/Wizard/Wizard.xml
+++ b/Character/Classes/Wizard/Wizard.xml
@@ -3,7 +3,12 @@
 	<baseclass>
 		<name>Wizard</name>
 		<hd>6</hd>
-		<proficiency>Intelligence, Wisdom</proficiency>
+		<proficiency>Intelligence, Wisdom, Arcana, History, Insight, Investigation, Medicine, Religion</proficiency>
+		<numSkills>2</numSkills>
+		<armor>none</armor>
+<weapons>daggers, darts, slings, quarterstaffs, light crossbows</weapons>
+<tools>none</tools>
+<wealth>4d4x10</wealth>
 		<spellAbility>Intelligence</spellAbility>
 		<autolevel level="1">
 			<slots>3,2,0,0,0,0,0,0,0,0</slots>
@@ -142,42 +147,22 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="6">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="10">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="12" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="14">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="18">
 			<feature>
@@ -186,12 +171,7 @@
 				<text>	By spending 8 hours in study, you can exchange one or both of the spells you chose for different spells of the same levels.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
-			</feature>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Homebrew/Classes/Blood Hunter/Blood Hunter.xml
+++ b/Homebrew/Classes/Blood Hunter/Blood Hunter.xml
@@ -162,7 +162,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="8" scoreImprovement="YES">
-			</feature>
 		</autolevel>
 		<autolevel level="9">
 			<feature>

--- a/Homebrew/Classes/Blood Hunter/Blood Hunter.xml
+++ b/Homebrew/Classes/Blood Hunter/Blood Hunter.xml
@@ -187,7 +187,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="12" scoreImprovement="YES">
-			</feature>
 		</autolevel>
 		<autolevel level="13">
 			<feature>
@@ -209,7 +208,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="16" scoreImprovement="YES">
-			</feature>
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -221,7 +219,6 @@
 			<!-- Archetype features -->
 		</autolevel>
 		<autolevel level="19" scoreImprovement="YES">
-			</feature>
 			<feature>
 				<name>Crimson Rite Damage Increase</name>
 				<text>At level 19, your Crimson Rite damage die increases to 1d12.</text>

--- a/Homebrew/Classes/Blood Hunter/Blood Hunter.xml
+++ b/Homebrew/Classes/Blood Hunter/Blood Hunter.xml
@@ -3,7 +3,12 @@
 	<baseclass name="Blood Hunter">
 		<name>Blood Hunter</name>
 		<hd>10</hd>
-		<proficiency>Strength, Wisdom</proficiency>
+		<proficiency>Strength, Wisdom, Athletics, Acrobatics, Arcana, Insight, Investigation, Survival</proficiency>
+		<numSkills>2</numSkills>
+		<armor>light armor, medium armor</armor>
+<weapons>simple weapons, martial weapons</weapons>
+<tools>alchemist's supplies</tools>
+<wealth>4d4x10</wealth>
 		<autolevel level="1">
 			<feature>
 				<name>Starting Proficiencies</name>
@@ -93,11 +98,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1, As normal, you can't increase an ability score above 20 using this feature.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -160,11 +161,7 @@
 		<autolevel level="7">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="8">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
+		<autolevel level="8" scoreImprovement="YES">
 			</feature>
 		</autolevel>
 		<autolevel level="9">
@@ -190,11 +187,7 @@
 		<autolevel level="11">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="12">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
+		<autolevel level="12" scoreImprovement="YES">
 			</feature>
 		</autolevel>
 		<autolevel level="13">
@@ -216,11 +209,7 @@
 		<autolevel level="15">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="16">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
+		<autolevel level="16" scoreImprovement="YES">
 			</feature>
 		</autolevel>
 		<autolevel level="17">
@@ -232,11 +221,7 @@
 		<autolevel level="18">
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="19">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>	If your DM allows the use of feats, you may instead take a feat.</text>
+		<autolevel level="19" scoreImprovement="YES">
 			</feature>
 			<feature>
 				<name>Crimson Rite Damage Increase</name>

--- a/Homebrew/Classes/Lingering Soul/Lingering Soul.xml
+++ b/Homebrew/Classes/Lingering Soul/Lingering Soul.xml
@@ -3,7 +3,11 @@
 	<baseclass name="Lingering Soul" HB="HB">
 		<name>Lingering Soul</name>
 		<hd>6</hd>
-		<proficiency>Constitution</proficiency>
+		<proficiency>Constitution, History, Investigation, Insight, Intimidation, Perception, Religion, Sleight of Hand, Stealth</proficiency>
+		<numSkills>3</numSkills>
+		<armor>None</armor>
+<weapons>None</weapons>
+<tools>None</tools>
 		<autolevel level="1">
 			<feature>
 				<name>Starting Proficiencies</name>
@@ -22,7 +26,7 @@
 				<text>• a trinket (rolled on the Trinkets table, PHB pg. 160)</text>
 				<text/>
 				<text>Taking over a dead character</text>
-				<text>If a deceased player character returns as a Lingering SOul, they lose all previous class levels and abilities, instead returning with a number of levels in Lingering Soul equal to one less than their previous character level. They retain any languages they knew in life, as well as racial benefits and abilities, but lose all previous skill proficiencies, saving throw proficiencies, feats, and Ability SCore improvements gained via class levels.</text>
+				<text>If a deceased player character returns as a Lingering Soul, they lose all previous class levels and abilities, instead returning with a number of levels in Lingering Soul equal to one less than their previous character level. They retain any languages they knew in life, as well as racial benefits and abilities, but lose all previous skill proficiencies, saving throw proficiencies, feats, and Ability Score improvements gained via class levels.</text>
 			</feature>
 			<feature>
 				<name>Spirit Binding</name>
@@ -75,11 +79,7 @@
 				<text>	Some items and artifacts cannot be consumed in this way (DM's discretion).</text>
 			</feature>
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -101,6 +101,8 @@
 				<text>	When you would receive half of the damage a possessed creature suffers from an attack, you can use your reaction to reduce it to a quarter of the damage suffered.</text>
 			</feature>
 		</autolevel>
+				<autolevel level="8" scoreImprovement="YES">
+		</autolevel>
 		<autolevel level="9">
 			<feature>
 				<name>Xenoglossia</name>
@@ -119,6 +121,8 @@
 		<autolevel level="11">
 			<!-- Archetype features -->
 		</autolevel>
+				<autolevel level="12" scoreImprovement="YES">
+		</autolevel>
 		<autolevel level="13">
 			<feature>
 				<name>Piercing Chill</name>
@@ -136,6 +140,8 @@
 		<autolevel level="15">
 			<!-- Archetype features -->
 		</autolevel>
+				<autolevel level="16" scoreImprovement="YES">
+		</autolevel>
 		<autolevel level="17">
 			<feature>
 				<name>Eternal Spirit</name>
@@ -150,6 +156,8 @@
 				<text>At 18th level, you have gained the ability to completely control a host. While possessing a living host, you can use your action to take total and precise control of the target. Until the end of your next turn, the creature takes only the actions you choose, and doesn't do anything that you don't allow it to do. During this time. you can also cause the creature to use a reaction, but this requires you to use your own reaction as well.</text>
 				<text>	Each time the host takes damage during a turn where you are controlling it this way, it makes a new Charisma saving throw against your possession. If the saving throw succeeds, the possession ends.</text>
 			</feature>
+		</autolevel>
+				<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>

--- a/Homebrew/Classes/Mist Walker/Mist Walker.xml
+++ b/Homebrew/Classes/Mist Walker/Mist Walker.xml
@@ -3,7 +3,12 @@
 	<baseclass name="Mist Walker" HB="HB">
 		<name>Mist Walker</name>
 		<hd>10</hd>
-		<proficiency>Dexterity, Intelligence</proficiency>
+		<proficiency>Dexterity, Intelligence, Acrobatics, Deception, History, Intimidation, Investigation, Perception, Persuasion, Sleight of Hand, Stealth</proficiency>
+		<numSkills>3</numSkills>
+		<armor>Light Armor, Shields</armor>
+<weapons>Simple Weapons, Short Swords, Scimitars, Rapiers</weapons>
+<tools>Poisoner's Kit</tools>
+<wealth>5d4x10</wealth>
 		<autolevel level="1">
 			<feature>
 				<name>Starting Proficiencies</name>
@@ -89,11 +94,7 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
-		<autolevel level="4">
-			<feature>
-				<name>Ability Score Improvement</name>
-				<text>When you reach 4th level, and again at 8th, 12th, 16th and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1, As normal, you can't increase an ability score above 20 using this feature.</text>
-			</feature>
+		<autolevel level="4" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="5">
 			<feature>
@@ -115,6 +116,8 @@
 			</feature>
 			<!-- Archetype features -->
 		</autolevel>
+		<autolevel level="8" scoreImprovement="YES">
+		</autolevel>
 		<autolevel level="9">
 			<feature>
 				<name>Tactical Precision</name>
@@ -130,6 +133,8 @@
 		<autolevel level="11">
 			<!-- Archetype features -->
 		</autolevel>
+		<autolevel level="12" scoreImprovement="YES">
+		</autolevel>
 		<autolevel level="13">
 			<feature>
 				<name>Misty Vision</name>
@@ -138,6 +143,8 @@
 		</autolevel>
 		<autolevel level="15">
 			<!-- Archetype features -->
+		</autolevel>
+		<autolevel level="16" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="17">
 			<feature>
@@ -150,6 +157,8 @@
 				<name>Greater Mist Walk</name>
 				<text>Starting at 18th level, as an action, you may use the Teleport spell as though you have cast it, without requiring spell components. If you target only yourself, you regain use of this ability after a long rest. If you target two or more creatures, you regain use of this ability after 1d6 days.</text>
 			</feature>
+		</autolevel>
+		<autolevel level="19" scoreImprovement="YES">
 		</autolevel>
 		<autolevel level="20">
 			<feature>


### PR DESCRIPTION
I'm unsure how recent a feature this is, but the app allows levels to be marked with an ASI tag which will take the user to a screen to do said asi, this is a much better experience that is currently lacking in the files.

In addition, the proficiencies do not exist on the classes, preventing the proper sections from being populated, which has also been fixed

Third, the number of skills and class skill list was not populated, making the character builder screen hard to navigate when all skills are shown

Lastly, starting wealth was not set on the classes was not set, I do not know for sure whether that was affecting the character builder starting wealth calculation, but it has been added regardless