### PR TITLE
fixed some archetype options being non-optional

### DIFF
--- a/Character/Classes/Cleric/Cleric (Order).xml
+++ b/Character/Classes/Cleric/Cleric (Order).xml
@@ -25,7 +25,7 @@
 				<name>Order Domain: Bonus Proficiencies</name>
 				<text>When you choose this domain at 1st level, you gain proficiency with heavy armor. You also gain proficiency in the Intimidation or Persuasion skill (your choice).</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Voice of Authority</name>
 				<text>Starting at 1st level, you can invoke the power of law to drive an ally to attack. If you cast a spell with a spell slot of 1st level or higher and target an ally with the spell, that ally can use their reaction immediately after the spell to make one weapon attack against a creature of your choice that you can see.</text>
 				<text>	If the spell targets more than one ally,you choose the ally who can make the attack.</text>

--- a/Character/Classes/Druid/Druid (Spores).xml
+++ b/Character/Classes/Druid/Druid (Spores).xml
@@ -20,11 +20,11 @@
 				<text>7th          blight, confusion</text>
 				<text>9th          cloudkill, contagion</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Halo of Spores</name>
 				<text>Starting at 2nd level, you are surrounded by invisible. necrotic spores that are harmless until you unleash them on a creature nearby. When a creature you can see moves into a space within 10 feet of you or starts its turn there, you can use your reaction to deal 1d4 necrotic damage to that creature unless it succeeds on a Constitution saving throw against your spell save DC. The necrotic damage increases to ld6 at 6th level, 1d8 at 10th level, and 1dlO at 14th level.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Symbiotic Entity</name>
 				<text>At 2nd level, you gain the ability to channel magic into your spores. As an action, you can expend a use of your Wild Shape feature to awaken those spores, rather than transforming into a beast form, and you gain 4 temporary hit points for each level you have in this class. While this feature is active, you gain the following benefits:</text>
 				<text>• When you deal your Halo of Spores damage, roll the damage die a second time and add it to the total.</text>

--- a/Character/Classes/Rogue/Rogue (Arcane Trickster).xml
+++ b/Character/Classes/Rogue/Rogue (Arcane Trickster).xml
@@ -73,7 +73,7 @@
 				<text>You can perform one of these tasks without being noticed by a creature if you succeed on a Dexterity (Sleight of Hand) check contested by the creature's Wisdom (Perception) check.</text>
 				<text>	In addition, you can use the bonus action granted by your Cunning Action to control the hand.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Arcane Trickster: Spellcasting</name>
 				<text>When you reach 3rd level, you gain the ability to cast spells. See chapter 10 for the general rules of spellcasting and chapter 11 for the wizard spell list.</text>
 				<text/>

--- a/Homebrew/Classes/Barbarian/Barbarian (Legendary Wrestler).xml
+++ b/Homebrew/Classes/Barbarian/Barbarian (Legendary Wrestler).xml
@@ -21,7 +21,7 @@
 				<name>Path of the Legendary Wrestler: Legendary Skills</name>
 				<text>Your knowledge in the arts of grappling allows you to grapple creatures up to two sizes larger than yourself instead of just one.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Vigorous Encouragement</name>
 				<text>You can use your action to say an encouraging phrase that's at least seven words long to a friendly creature that's within 30 feet of you. The creature being encouraged has advantage on all attack rolls it makes as well as ability checks using Strength, Constitution, Charisma and Dexterity (Acrobatics). The effect lasts for a number of rounds equal to your Charisma modifier + 1 round (minimum of 1 round), finishing at the start of your turn.</text>
 				<text>	The effect will end early whenever the creature takes damage. However, a friendly creature (Player Characters or NPCs) can use its reaction to say encouraging phrases that's at least seven words long to prevent the effect from ending this way.</text>

--- a/Homebrew/Classes/Cleric/Cleric (Air).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Air).xml
@@ -23,7 +23,7 @@
 				<name>Air Domain: Bonus Proficiency</name>
 				<text>When you choose this domain at 1st level, you gain the fist of air cantrip if you don't already know it.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Air Domain: Reed in the Wind</name>
 				<text>Also starting at 1st level, you can surrender your motion to the divine winds, flowing out of the way of incoming harm. When an attacker that you can see hits you with an attack, you can use your reaction to halve the attack's damage against you, provided you are not restrained or prone.</text>
 				<text>	You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest.</text>

--- a/Homebrew/Classes/Cleric/Cleric (Balance).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Balance).xml
@@ -23,7 +23,7 @@
 				<name>Balance Domain: Bonus Proficiency</name>
 				<text>When you choose this domain at 1st level, you gain proficiency with heavy armor and Insight.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Balance Domain: Servant oF Balance</name>
 				<text>Also starting at 1st level, you can use your action to touch a willing creature other than yourself and spend 1 Hit Die. Roll the die and the creature touched regains hit points equal to the number rolled.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Beauty).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Beauty).xml
@@ -23,7 +23,7 @@
 				<name>Beauty Domain: Bonus Proficiency</name>
 				<text>When you choose this domain at 1st level, you gain the friends cantrip if you don't already have it.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Beauty Domain: Alluring Presence</name>
 				<text>You become proficient in Deception or Persuasion. Your proficiency bonus is doubled for any ability check you make using the skill you chose.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Blood).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Blood).xml
@@ -24,7 +24,7 @@
 				<name>Blood Domain: Bonus Proficiency</name>
 				<text>At 1st Level, you gain proficiency with martial weapons.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Blood Domain: Bloodletting Focus</name>
 				<text>From 1st level, your divine magics draw the blood from inflicted wounds, worsening the agony of your nearby foes. When you use a spell of 1st level or higher to damage to any creatures that have blood, those creatures suffer additional necrotic damage equal to 2 + the spell's level.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Creation).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Creation).xml
@@ -23,7 +23,7 @@
 				<name>Creation Domain: Disciple of Creation</name>
 				<text>When you choose this domain at 1st level, you gain proficiency with all kinds of artisans' tools. Your proficiency bonus is doubled for any ability check you make that uses artisans' tools.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Creation Domain: Gift of Making</name>
 				<text>Also when you choose this domain at 1st level, you gain the thaumaturgy cantrip if you do not already know it, and can use it to create a nonmagical trinket or tool that can fit into your hand. The object created lasts until the end of your next turn.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Earth).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Earth).xml
@@ -23,7 +23,7 @@
 				<name>Earth Domain: Strength of the Mountain</name>
 				<text>When you choose this domain at 1st level, you gain proficiency with heavy armor. Additionally, you have advantage on Strength saving throws.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Earth Domain: Endurance of Stone</name>
 				<text>Also starting at 1st level, your hit point maximum increases by 1, and increases by 1 again whenever you gain a level in this class.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Fire).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Fire).xml
@@ -23,7 +23,7 @@
 				<name>Fire Domain: Bonus Cantrip</name>
 				<text>When you choose this domain at 1st level, you gain the fire bolt and produce flame cantrips if you don't already know them. These cantrips count as cleric spells for you.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Fire Domain: Allied to the Fire</name>
 				<text>Also starting at 1st level, you gain resistance to fire damage.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Repose).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Repose).xml
@@ -23,7 +23,7 @@
 				<name>Repose Domain: Power of the Grave</name>
 				<text>When you choose this domain at 1st level, you learn two necromancy cantrips chosen from any class's spell list.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Repose Domain: Barring Death's Door</name>
 				<text>Also starting at 1st level, creatures that you are friendly to that are within 60 feet of you have advantage on death saving throws.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Solidarity).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Solidarity).xml
@@ -23,7 +23,7 @@
 				<name>Solidarity Domain: Bonus Proficiency</name>
 				<text>When you choose this domain at 1st level, you gain proficiency with heavy armor.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Solidarity Domain: Solidarity's Action</name>
 				<text>Also at 1st level, when you take the Help action to aid an ally's attack, you can make one weapon attack as a bonus action. You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain expended uses when you finish a long rest.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Strength).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Strength).xml
@@ -23,7 +23,7 @@
 				<name>Strength Domain: Acolyte of Strength</name>
 				<text>At 1st level, you learn one druid cantrip of your choice. You also gain proficiency in one of the following skills of your choice: Animal Handling, Athletics, Nature, or Survival.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Strength Domain: Bonus Proficiency</name>
 				<text>Also at 1st level, you gain proficiency with heavy armor.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Survival).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Survival).xml
@@ -24,7 +24,7 @@
 				<name>Survival Domain: Bonus Proficiency</name>
 				<text>When you choose this domain at 1st level, you gain proficiency in the Survival and Nature skills. Your proficiency bonus is doubled for any ability checks you make that use those skills.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Survival Domain: Stand the Fallen</name>
 				<text>Also starting at 1st level, when you cast the spare the dying cantrip, you can make the following changes to the spell: change the range from touch to 30 feet, and the creature gains 1 hit point instead of becoming stable.</text>
 				<text>	You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long or short rest.</text>

--- a/Homebrew/Classes/Cleric/Cleric (Travel).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Travel).xml
@@ -23,7 +23,7 @@
 				<name>Travel Domain: Shift</name>
 				<text>Starting when you choose this domain at 1st level, as a bonus action you can move up to 10 feet. This movement does not provoke opportunity attacks.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Travel Domain: Far Strider</name>
 				<text>Also starting at 1st level, you and up to 6 companions, along with one mount for each companion, do not su er levels of exhaustion for traveling for more than 8 hours each day. Additionally, while doing nothing but traveling, you, your companions, and your mounts do not need to sleep, and you can travel at a fast pace without taking a penalty to passive Wisdom (Perception) checks because of that speed.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Tyranny).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Tyranny).xml
@@ -24,7 +24,7 @@
 				<name>Tyranny Domain: Bonus Proficiency</name>
 				<text>At 1st level, you gain proficiency with martial weapons and heavy armor.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Tyranny Domain: Blessing of the Tyrant</name>
 				<text>Starting when you choose this domain at 1st level, you can use your action to touch a willing creature other than yourself to give it advantage on Charisma (Intimidation) checks. The blessing lasts for 1 hour or until you use this feature again.</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Water).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Water).xml
@@ -23,7 +23,7 @@
 				<name>Water Domain: Relentless as the Tides</name>
 				<text>When you choose this domain at 1st level, you gain proficiency with heavy armor. Additionally, wearing heavy armor does not affect your ability to swim or encumber your movement in water.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Water Domain: Destructive as the Flood</name>
 				<text>Also starting at 1st level, your damaging spells are more effective. Whenever you roll damage for a cleric spell of 1st level or higher, add your Wisdom modifier to the damage (minimum of 1)</text>
 			</feature>

--- a/Homebrew/Classes/Cleric/Cleric (Zeal).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Zeal).xml
@@ -23,7 +23,7 @@
 				<name>Zeal Domain: Bonus Proficiencies</name>
 				<text>At 1st level, you gain proficiency with martial weapons and heavy armor.</text>
 			</feature>
-			<feature>
+			<feature optional="YES">
 				<name>Zeal Domain: Priest of Zeal</name>
 				<text>From 1st level, Hazoret delivers bolts of inspiration to you while you are engaged in battle. When you use the Attack action, you can make one weapon attack as a bonus action.</text>
 				<text>	You can use this feature a num-ber of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest.</text>


### PR DESCRIPTION
This was including items by default for any character of that class, and with so many, that could be hard to see if you are using one high up on the list