### PR TITLE
Spells script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
-python:
-    - "2.7"
+python: "3.6"
+
+before_install:
+    - sudo apt-get install -y libxml2-utils
+
 script:
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch
     - git diff --name-only --diff-filter=AM origin/${TRAVIS_BRANCH} HEAD | grep ".xml" | grep -v "Templates.xml" | xargs -d '\n' xmllint --noout
+    - python fix_spells.py --dry-run --verbose
     - python create_compendiums.py
     - python create_compendiums.py --excludes
     - python create_compendiums.py --excludes --subtype-format usable
-before_install:
-      - sudo apt-get install -y libxml2-utils

--- a/Bestiary/Curse of Strahd.xml
+++ b/Bestiary/Curse of Strahd.xml
@@ -60,7 +60,7 @@
 			<name>Summon Swarms of Insects (Recharges after a Short or Long Rest)</name>
 			<text>Baba Lysaga summons 1d4 swarms of insects. A summoned swarm appears in an unoccupied space within 60 feet of Baba Lysaga and acts as her ally. It remains until it dies or until Baba Lysaga dismisses it as an action.</text>
 		</action>
-		<spells>acid splash, fire bolt, light, mage hand, prestidigitation, detect magic, magic missile, sleep, witch bolt, crown of madness, enlarge/reduce, misty step, dispel magic, fireball, lightning bolt, blight, Everard's black tentacles, polymorph, cloudkill, geas, scrying, programmed illusion, true seeing, finger of death, mirage arcane, power word stun</spells>
+		<spells>Acid Splash, Fire Bolt, Light, Mage Hand, Prestidigitation, Detect Magic, Magic Missile, Sleep, Witch Bolt, Crown of Madness, Enlarge/Reduce, Misty Step, Dispel Magic, Fireball, Lightning Bolt, Blight, Everard's black tentacles, Polymorph, Cloudkill, Geas, Scrying, Programmed Illusion, True Seeing, Finger of Death, Mirage Arcane, Power Word Stun</spells>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
 	</monster>
 	<monster>
@@ -212,7 +212,7 @@
 			<text>Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 2 (1d4) piercing damage.</text>
 			<attack>Dagger|2|1d4</attack>
 		</action>
-		<spells>mage hand, prestidigitation, ray of frost, ray of sickness, sleep, Tasha's hideous laughter, alter self, invisibility</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Ray of Sickness, Sleep, Tasha's Hideous Laughter, Alter Self, Invisibility</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -280,7 +280,7 @@
 			<name>Evil Eye (Recharges after a Short or Long Rest)</name>
 			<text>Ezmerelda targets one creature that she can see within 10 feet of her and casts one of the following spells on the target (save DC 14), requiring neither somatic nor material components to do so: animal friendship, charm person, or hold person. If the target succeeds on the initial saving throw, Ezmerelda is blinded until the end of her next turn. Once a target succeeds on a saving throw against this effect, it is immune to the Evil Eye power of all Vistani for 24 hours.</text>
 		</action>
-		<spells>fire bolt, light, mage hand, prestidigitation, protection from evil and good, magic missile, shield, darkvision, knock, mirror image, clairvoyance, lightning bolt, magic circle, greater invisibility</spells>
+		<spells>Fire Bolt, Light, Mage Hand, Prestidigitation, Protection from Evil and Good, Magic Missile, Shield, Darkvision, Knock, Mirror Image, Clairvoyance, Lightning Bolt, Magic Circle, Greater Invisibility</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -326,7 +326,7 @@
 			<name>False Appearance</name>
 			<text>While the figure in the portrait remains motionless, it is indistinguishable from a normal painting.</text>
 		</trait>
-		<spells>counterspell, crown of madness, hypnotic pattern, telekinesis</spells>
+		<spells>Counterspell, Crown of Madness, Hypnotic Pattern, Telekinesis</spells>
 	</monster>
 	<monster>
 		<name>Izek Strazni</name>
@@ -425,7 +425,7 @@
 			<name>Evil Eye (Recharges after a Short or Long Rest)</name>
 			<text>Madam Eva targets one creature that she can see within 10 feet of her and casts one of the following spells on the target (save DC 17), requiring neither somatic nor material components to do so: animal friendship, charm person, or hold person. If the target succeeds on the initial saving throw, Madam Eva is blinded until the end of her next turn. Once a target succeeds on a saving throw against this effect, it is immune to the Evil Eye power of all Vistani for 24 hours.</text>
 		</action>
-		<spells>light, mending, sacred flame, thaumaturgy, bane, command, detect evil and good, protection from evil and good, lesser restoration, protection from poison, spiritual weapon, create food and water, speak with dead, spirit guardians, divination, freedom of movement, guardians of faith, greater restoration, raise dead, find the path, harm, true seeing, fire storm, regenerate, earthquake</spells>
+		<spells>Light, Mending, Sacred Flame, Thaumaturgy, Bane, Command, Detect Evil and Good, Protection from Evil and Good, Lesser Restoration, Protection from Poison, Spiritual Weapon, Create Food and Water, Speak with Dead, Spirit Guardians, Divination, Freedom of Movement, guardians of faith, Greater Restoration, Raise Dead, Find the Path, Harm, True Seeing, Fire Storm, Regenerate, Earthquake</spells>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
 	</monster>
 	<monster>
@@ -647,7 +647,7 @@
 			<text>Ranged Weapon Attack: +10 to hit, range 20/60 ft., one target. Hit: 8 (1d4+6) piercing damage plus 5 (2d4) poison damage.</text>
 			<attack>Poisoned Dart|10|1d4+6+2d4</attack>
 		</action>
-		<spells>misty step, phantom steed, magic weapon, nondetection</spells>
+		<spells>Misty Step, Phantom Steed, Magic Weapon, Nondetection</spells>
 	</monster>
 	<monster>
 		<name>Rictavio</name>
@@ -701,7 +701,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d6+1) bludgeoning damage (wooden cane) or piercing damage (silvered sword).</text>
 			<attack>Sword Cane|4|1d6+1</attack>
 		</action>
-		<spells>guidance, light, mending, thaumaturgy, cure wounds, detect evil and good, protection from evil and good, sanctuary, augury, lesser restoration, protection from poison, magic circle, remove curse, speak with dead, death ward, freedom of movement, dispel evil and good</spells>
+		<spells>Guidance, Light, Mending, Thaumaturgy, Cure Wounds, Detect Evil and Good, Protection from Evil and Good, Sanctuary, Augury, Lesser Restoration, Protection from Poison, Magic Circle, Remove Curse, Speak with Dead, Death Ward, Freedom of Movement, Dispel Evil and Good</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -863,7 +863,7 @@
 			<name>Bite (Costs 2 Actions)</name>
 			<text>Strahd makes one bite attack.</text>
 		</legendary>
-		<spells>mage hand, prestidigitation, ray of frost, comprehend languages, fog cloud, sleep, detect thoughts, gust of wind, mirror image, animate dead, fireball, nondetection, blight, greater invisibility, polymorph, animate objects, scrying</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Comprehend Languages, Fog Cloud, Sleep, Detect Thoughts, Gust of Wind, Mirror Image, Animate Dead, Fireball, Nondetection, Blight, Greater Invisibility, Polymorph, Animate Objects, Scrying</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Curse of Strahd.xml
+++ b/Bestiary/Curse of Strahd.xml
@@ -40,7 +40,7 @@
 			<text>1st level (4 slots): detect magic, magic missile, sleep, witch bolt</text>
 			<text>2nd level (3 slots): crown of madness, enlarge/reduce, misty step</text>
 			<text>3rd level (3 slots): dispel magic, fireball, lightning bolt</text>
-			<text>4th level (3 slots): blight, Everard's black tentacles, polymorph</text>
+			<text>4th level (3 slots): blight, Evard's black tentacles, polymorph</text>
 			<text>5th level (2 slots): cloudkill, geas, scrying</text>
 			<text>6th level (1 slot): programmed illusion, true seeing</text>
 			<text>7th level (1 slot): finger of death, mirage arcane</text>
@@ -60,7 +60,7 @@
 			<name>Summon Swarms of Insects (Recharges after a Short or Long Rest)</name>
 			<text>Baba Lysaga summons 1d4 swarms of insects. A summoned swarm appears in an unoccupied space within 60 feet of Baba Lysaga and acts as her ally. It remains until it dies or until Baba Lysaga dismisses it as an action.</text>
 		</action>
-		<spells>Acid Splash, Fire Bolt, Light, Mage Hand, Prestidigitation, Detect Magic, Magic Missile, Sleep, Witch Bolt, Crown of Madness, Enlarge/Reduce, Misty Step, Dispel Magic, Fireball, Lightning Bolt, Blight, Everard's black tentacles, Polymorph, Cloudkill, Geas, Scrying, Programmed Illusion, True Seeing, Finger of Death, Mirage Arcane, Power Word Stun</spells>
+		<spells>Acid Splash, Fire Bolt, Light, Mage Hand, Prestidigitation, Detect Magic, Magic Missile, Sleep, Witch Bolt, Crown of Madness, Enlarge/Reduce, Misty Step, Dispel Magic, Fireball, Lightning Bolt, Blight, Evard's Black Tentacles, Polymorph, Cloudkill, Geas, Scrying, Programmed Illusion, True Seeing, Finger of Death, Mirage Arcane, Power Word Stun</spells>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
 	</monster>
 	<monster>
@@ -406,7 +406,7 @@
 			<text>1st level (4 slots): bane, command, detect evil and good, protection from evil and good</text>
 			<text>2nd level (3 slots): lesser restoration, protection from poison, spiritual weapon</text>
 			<text>3rd level (3 slots): create food and water, speak with dead, spirit guardians</text>
-			<text>4th level (3 slots): divination, freedom of movement, guardians of faith</text>
+			<text>4th level (3 slots): divination, freedom of movement, guardian of faith</text>
 			<text>5th level (2 slots): greater restoration, raise dead</text>
 			<text>6th level (1 slot): find the path, harm, true seeing</text>
 			<text>7th level (1 slot): fire storm, regenerate</text>
@@ -425,7 +425,7 @@
 			<name>Evil Eye (Recharges after a Short or Long Rest)</name>
 			<text>Madam Eva targets one creature that she can see within 10 feet of her and casts one of the following spells on the target (save DC 17), requiring neither somatic nor material components to do so: animal friendship, charm person, or hold person. If the target succeeds on the initial saving throw, Madam Eva is blinded until the end of her next turn. Once a target succeeds on a saving throw against this effect, it is immune to the Evil Eye power of all Vistani for 24 hours.</text>
 		</action>
-		<spells>Light, Mending, Sacred Flame, Thaumaturgy, Bane, Command, Detect Evil and Good, Protection from Evil and Good, Lesser Restoration, Protection from Poison, Spiritual Weapon, Create Food and Water, Speak with Dead, Spirit Guardians, Divination, Freedom of Movement, guardians of faith, Greater Restoration, Raise Dead, Find the Path, Harm, True Seeing, Fire Storm, Regenerate, Earthquake</spells>
+		<spells>Light, Mending, Sacred Flame, Thaumaturgy, Bane, Command, Detect Evil and Good, Protection from Evil and Good, Lesser Restoration, Protection from Poison, Spiritual Weapon, Create Food and Water, Speak with Dead, Spirit Guardians, Divination, Freedom of Movement, Guardian of Faith, Greater Restoration, Raise Dead, Find the Path, Harm, True Seeing, Fire Storm, Regenerate, Earthquake</spells>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Dragon Heist.xml
+++ b/Bestiary/Dragon Heist.xml
@@ -1619,7 +1619,7 @@
 		</trait>
 		<spellAbility>Wisdom</spellAbility>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
-		<spells>Guidance, Light, Mending, Spare the Dying, Thaumaturgy, Charm Person, Command, Detect magic, Disguise Self, Protection from Evil and Good, Sanctuary, Augury, Lesser Restoration, Mirror Image, Pass without Trace, Spiritual Weapon, Blink, Clairvoyance, Dispel Magic, Magic Circle, Protectionfrom Energy, Banishment, Dimension Door, Divination, Freedom of Movement, Polymorph, Dominate Person, Flame Strike, Modify Memory, Insect Plague, Heal, Divine Word, Earthquake</spells>
+		<spells>Guidance, Light, Mending, Spare the Dying, Thaumaturgy, Charm Person, Command, Detect Magic, Disguise Self, Protection from Evil and Good, Sanctuary, Augury, Lesser Restoration, Mirror Image, Pass without Trace, Spiritual Weapon, Blink, Clairvoyance, Dispel Magic, Magic Circle, Protectionfrom Energy, Banishment, Dimension Door, Divination, Freedom of Movement, Polymorph, Dominate Person, Flame Strike, Modify Memory, Insect Plague, Heal, Divine Word, Earthquake</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Victoro makes two attacks with his rapier.</text>

--- a/Bestiary/Dragon Heist.xml
+++ b/Bestiary/Dragon Heist.xml
@@ -791,11 +791,11 @@
 			<text>Cantrips (at will): guidance, light, sacred flame, spare the dying</text>
 			<text>1st level (4 slots): detect evil and good, healing word, sanctuary, shield of faith</text>
 			<text>2nd level (3 slots): calm emotions, prayer ofhealing, silence</text>
-			<text>3rd level (2 slots): protection from energy. remove curse, sending</text>
+			<text>3rd level (2 slots): protection from energy, remove curse, sending</text>
 		</trait>
 		<spellAbility>Wisdom</spellAbility>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
-		<spells>Guidance, Light, Sacred Flame, Spare the Dying, Detect Evil and Good, Healing Word, Sanctuary, Shield of Faith, Calm Emotions, Prayer of Healing, Silence, Protection from Energy. Remove Curse, Sending</spells>
+		<spells>Guidance, Light, Sacred Flame, Spare the Dying, Detect Evil and Good, Healing Word, Sanctuary, Shield of Faith, Calm Emotions, Prayer of Healing, Silence, Protection from Energy, Remove Curse, Sending</spells>
 		<trait>
 			<name>Evasion</name>
 			<text> If Hlam is subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage ifhe fails. He can't use this trait if he's incapacitated.</text>
@@ -1086,7 +1086,7 @@
 			<text>2nd level (at will): detect thoughts, invisibility, misty step</text>
 			<text>3rd level (3 slots): counterspell, fly, sending, tongues</text>
 			<text>4th level (3 slots): banishment, greater invisibility, Otiluke's resilient sphere</text>
-			<text>5th level (3 slots): cone of cold, geas, Rory's telepathic bond</text>
+			<text>5th level (3 slots): cone of cold, geas, Rary's telepathic bond</text>
 			<text>6th level (2 slots): globe of invulnerability, mass suggestion</text>
 			<text>7th level (1 slot): prismatic spray, teleport</text>
 			<text>8th level (1 slot): feeblemind, power word stun</text>
@@ -1094,7 +1094,7 @@
 		</trait>
 		<spellAbility>Intelligence</spellAbility>
 		<slots>0,0,3,3,3,2,1,1,1</slots>
-		<spells>Light, Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Detect Magic, Disguise Self, Magic Missile, Shield, Detect Thoughts, Invisibility, Misty Step, Counterspell, Fly, Sending, Tongues, Banishment, Greater Invisibility, Otiluke's Resilient Sphere, Cone of Cold, Geas, Rory's Telepathic Bond, Globe of Invulnerability, Mass Suggestion, Prismatic Spray, Teleport, Feeblemind, Power Word Stun, Time Stop</spells>
+		<spells>Light, Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Detect Magic, Disguise Self, Magic Missile, Shield, Detect Thoughts, Invisibility, Misty Step, Counterspell, Fly, Sending, Tongues, Banishment, Greater Invisibility, Otiluke's Resilient Sphere, Cone of Cold, Geas, Rary's Telepathic Bond, Globe of Invulnerability, Mass Suggestion, Prismatic Spray, Teleport, Feeblemind, Power Word Stun, Time Stop</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Multiattack. Laeral makes three attacks with her silver hair and flame tongue, in any combination. She can cast one of her cantrips or 1st-level spells before or after making these attacks.</text>
@@ -1610,7 +1610,7 @@
 			<text>Cantrips (at will): guidance, light, mending, spare the dying, thaumaturgy</text>
 			<text>1st level (4 slots): charm person, command, detect rragic, disguise self, protectionfrom evil and good, sanctuary</text>
 			<text>2nd level (3 slots): augury, lesser restoration, mirror image, pass without trace, spiritual weapon</text>
-			<text>3rd level (3 slots): blink, clairvoyance, dispel magic, magic circle, protectionfrom energy</text>
+			<text>3rd level (3 slots): blink, clairvoyance, dispel magic, magic circle, protection from energy</text>
 			<text>4th level (3 slots): banishment, dimension door, divination, freedom of movement, polymorph</text>
 			<text>5th level (2 slots): dominate person, flame strike, modify memory, insect plague</text>
 			<text>6th level (1 slot): heal</text>
@@ -1619,7 +1619,7 @@
 		</trait>
 		<spellAbility>Wisdom</spellAbility>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
-		<spells>Guidance, Light, Mending, Spare the Dying, Thaumaturgy, Charm Person, Command, Detect Magic, Disguise Self, Protection from Evil and Good, Sanctuary, Augury, Lesser Restoration, Mirror Image, Pass without Trace, Spiritual Weapon, Blink, Clairvoyance, Dispel Magic, Magic Circle, Protectionfrom Energy, Banishment, Dimension Door, Divination, Freedom of Movement, Polymorph, Dominate Person, Flame Strike, Modify Memory, Insect Plague, Heal, Divine Word, Earthquake</spells>
+		<spells>Guidance, Light, Mending, Spare the Dying, Thaumaturgy, Charm Person, Command, Detect Magic, Disguise Self, Protection from Evil and Good, Sanctuary, Augury, Lesser Restoration, Mirror Image, Pass without Trace, Spiritual Weapon, Blink, Clairvoyance, Dispel Magic, Magic Circle, Protection from Energy, Banishment, Dimension Door, Divination, Freedom of Movement, Polymorph, Dominate Person, Flame Strike, Modify Memory, Insect Plague, Heal, Divine Word, Earthquake</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Victoro makes two attacks with his rapier.</text>

--- a/Bestiary/Dungeon of the Mad Mage.xml
+++ b/Bestiary/Dungeon of the Mad Mage.xml
@@ -115,7 +115,7 @@
 		</trait>
 		<spellAbility>Wisdom</spellAbility>
 		<slots>4,3,3,3,3,1,1,1,1</slots>
-		<spells>Druidcraft, Mending, Poison Spray, Produce Flame, Cure Wounds, Entangle, Faerie Fire, Speak with Animals, Animal Messenger, Beast Sense, Hold Person, Conjure Animals, Meld into Stone, Water Breathing, Dominate Beast, Locate Creature, Stoneskin, Wall of Fire, Commune With Nature, Mass Cure Wounds, Tree Stride, Heal, Heroes' Feast, Sunbeam, Fire storm, Animal Shapes, Foresight</spells>
+		<spells>Druidcraft, Mending, Poison Spray, Produce Flame, Cure Wounds, Entangle, Faerie Fire, Speak with Animals, Animal Messenger, Beast Sense, Hold Person, Conjure Animals, Meld into Stone, Water Breathing, Dominate Beast, Locate Creature, Stoneskin, Wall of Fire, Commune with Nature, Mass Cure Wounds, Tree Stride, Heal, Heroes' Feast, Sunbeam, Fire Storm, Animal Shapes, Foresight</spells>
 		<action>
 			<name>Scimitar</name>
 			<text>Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage.</text>

--- a/Bestiary/Guildmaster's Guide to Ravnica.xml
+++ b/Bestiary/Guildmaster's Guide to Ravnica.xml
@@ -3965,7 +3965,7 @@
 			<text>1/day each: conjure fey, mass cure wounds</text>
 		</trait>
 		<spellAbility>Wisdom</spellAbility>
-		<spells>Dispel magic, Druidcraft, Bless, Conjure Animals, Giant Insect, Moonbeam, Plant Growth, Spike Growth, Suggestion, Conjure Fey, Mass Cure Wounds</spells>
+		<spells>Dispel Magic, Druidcraft, Bless, Conjure Animals, Giant Insect, Moonbeam, Plant Growth, Spike Growth, Suggestion, Conjure Fey, Mass Cure Wounds</spells>
 		<trait>
 			<name>Legendary Resistance (3/day)</name>
 			<text>If Trostani fails a saving throw, she can choose to succeed instead.</text>

--- a/Bestiary/Guildmaster's Guide to Ravnica.xml
+++ b/Bestiary/Guildmaster's Guide to Ravnica.xml
@@ -554,7 +554,7 @@
 			<text>The lich is a 14th-level Golgari spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The lich has the following wizard spells prepared:</text>
 			<text>Cantrips (at will): acid splash, chill touch, mage hand, poison spray, prestidigitation</text>
 			<text>1st level (4 slots): chromatic orb, magic missile, ray of sickness</text>
-			<text>2nd level (3 slots): Melfs acid arrow, ray of enfeeblement, spider climb, web</text>
+			<text>2nd level (3 slots): Melf's acid arrow, ray of enfeeblement, spider climb, web</text>
 			<text>3rd level (3 slots): animate dead, bestow curse, fear, vampiric touch</text>
 			<text>4th level (3 slots): blight, Evard's black tentacles</text>
 			<text>5th level (2 slots): cloudkill, insect plague</text>
@@ -563,7 +563,7 @@
 		</trait>
 		<slots>4,3,3,3,2,1,1,0,0</slots>
 		<spellAbility>Intelligence</spellAbility>
-		<spells>Acid Splash, Chill Touch, Mage Hand, Poison Spray, Prestidigitation, Chromatic Orb, Magic Missile, Ray of Sickness, Melfs Acid Arrow, Ray of Enfeeblement, Spider Climb, Web, Animate Dead, Bestow Curse, Fear, Vampiric Touch, Blight, Evard's Black Tentacles, Cloudkill, Insect Plague, Circle of Death, Create Undead, Finger of Death</spells>
+		<spells>Acid Splash, Chill Touch, Mage Hand, Poison Spray, Prestidigitation, Chromatic Orb, Magic Missile, Ray of Sickness, Melf's Acid Arrow, Ray of Enfeeblement, Spider Climb, Web, Animate Dead, Bestow Curse, Fear, Vampiric Touch, Blight, Evard's Black Tentacles, Cloudkill, Insect Plague, Circle of Death, Create Undead, Finger of Death</spells>
 		<trait>
 			<name>Turn Resistance</name>
 			<text>The lich has advantage on saving throws against any effect that turns undead.</text>
@@ -2622,12 +2622,12 @@
 			<text>1st level (4 slots): guiding bolt, healing word, heroism, shield of faith</text>
 			<text>2nd level (3 slots): lesser restoration, scorching ray</text>
 			<text>3rd level (3 slots): blinding smite, crusader's mantle, revivify</text>
-			<text>4th level (3 slots): banishment, wolf of fire</text>
+			<text>4th level (3 slots): banishment, wall of fire</text>
 			<text>5th level (1 slot): flame strike</text>
 		</trait>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 		<spellAbility>Wisdom</spellAbility>
-		<spells>Fire Bolt, Light, Sacred Flame, Spare the Dying, Guiding Bolt, Healing Word, Heroism, Shield of Faith, Lesser Restoration, Scorching Ray, Blinding Smite, Crusader's Mantle, Revivify, Banishment, Wolf of Fire, Flame Strike</spells>
+		<spells>Fire Bolt, Light, Sacred Flame, Spare the Dying, Guiding Bolt, Healing Word, Heroism, Shield of Faith, Lesser Restoration, Scorching Ray, Blinding Smite, Crusader's Mantle, Revivify, Banishment, Wall of Fire, Flame Strike</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>The firefist makes two greatsword attacks.</text>
@@ -2947,7 +2947,7 @@
 			<text>Jarad is a 14th-level Golgari spellcaster. His spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spellattacks). Jarad has the following wizard spells prepared:</text>
 			<text>Cantrips (at will): acid splash, chill touch, mage hand, poison spray, prestidigitation</text>
 			<text>1st level (4 slots): entangle, ray ofsickness, sleep</text>
-			<text>2nd level (3 slots): Melfs acid arrow, ray of enfeeblement, spider climb, web</text>
+			<text>2nd level (3 slots): Melf's acid arrow, ray of enfeeblement, spider climb, web</text>
 			<text>3rd level (3 slots): animate dead, plant growth, vampiric touch</text>
 			<text>4th level (3 slots): blight, giant insect, grasping vine</text>
 			<text>5th level (2 slots): cloudkill, insect plague</text>
@@ -2956,7 +2956,7 @@
 		</trait>
 		<slots>4,3,3,3,2,1,1,0,0</slots>
 		<spellAbility>Intelligence</spellAbility>
-		<spells>Acid Splash, Chill Touch, Mage Hand, Poison Spray, Prestidigitation, Entangle, Ray of Sickness, Sleep, Melfs Acid Arrow, Ray of Enfeeblement, Spider Climb, Web, Animate Dead, Plant Growth, Vampiric Touch, Blight, Giant Insect, Grasping Vine, Cloudkill, Insect Plague, Circle of Death, Create Undead, Finger of Death, Forcecage</spells>
+		<spells>Acid Splash, Chill Touch, Mage Hand, Poison Spray, Prestidigitation, Entangle, Ray of Sickness, Sleep, Melf's Acid Arrow, Ray of Enfeeblement, Spider Climb, Web, Animate Dead, Plant Growth, Vampiric Touch, Blight, Giant Insect, Grasping Vine, Cloudkill, Insect Plague, Circle of Death, Create Undead, Finger of Death, Forcecage</spells>
 		<trait>
 			<name>Spore Infusion</name>
 			<text>Jarad is surrounded by a cloud of spores. As a bonus action, he can cause the spores to deal 11 (2d10) poison damage to a creature he can see within 10 feet of him.</text>
@@ -3206,7 +3206,7 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The druid is a 12th-level Gruul spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). It has the following druid spells prepared:</text>
-			<text>Cantrips (at will): druidcraft, produce fire, resistance, thorn whip</text>
+			<text>Cantrips (at will): druidcraft, produce flame, resistance, thorn whip</text>
 			<text>1st level (4 slots): cure wounds, faerie fire, thunderwave</text>
 			<text>2nd level (3 slots): beast sense, flame blade, pass without trace</text>
 			<text>3rd level (3 slots): conjure animals, dispel magic, plant growth</text>
@@ -3216,7 +3216,7 @@
 		</trait>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 		<spellAbility>Wisdom</spellAbility>
-		<spells>Druidcraft, Produce Fire, Resistance, Thorn Whip, Cure Wounds, Faerie Fire, Thunderwave, Beast Sense, Flame Blade, Pass without Trace, Conjure Animals, Dispel Magic, Plant Growth, Dominate Beast, Freedom of Movement, Wall of Fire, Commune with Nature, Conjure Elemental, Scrying, Transport via Plants, Wall of Thorns</spells>
+		<spells>Druidcraft, Produce Flame, Resistance, Thorn Whip, Cure Wounds, Faerie Fire, Thunderwave, Beast Sense, Flame Blade, Pass without Trace, Conjure Animals, Dispel Magic, Plant Growth, Dominate Beast, Freedom of Movement, Wall of Fire, Commune with Nature, Conjure Elemental, Scrying, Transport via Plants, Wall of Thorns</spells>
 		<action>
 			<name>Quarterstaff</name>
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>

--- a/Bestiary/Hoard of the Dragon Queen.xml
+++ b/Bestiary/Hoard of the Dragon Queen.xml
@@ -82,7 +82,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or ranged 20 ft./60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
 			<attack>Dagger|5|1d4+3</attack>
 		</action>
-		<spells>mage hand, prestidigitation, ray of frost, shocking grasp, fog cloud, magic missile, shield, thunderwave, invisibility, misty step, scorching ray, counterspell, dispel magic, fireball</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Shocking Grasp, Fog Cloud, Magic Missile, Shield, Thunderwave, Invisibility, Misty Step, Scorching Ray, Counterspell, Dispel Magic, Fireball</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -131,7 +131,7 @@
 			<text>Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) piercing damage.</text>
 			<attack>Morningstar|10|3d8+8</attack>
 		</action>
-		<spells>fog cloud, levitate, light, mage hand, prestidigitation, detect magic, identify, magic missile, shield, gust of wind, misty step, shatter, fly, lightning bolt</spells>
+		<spells>Fog Cloud, Levitate, Light, Mage Hand, Prestidigitation, Detect Magic, Identify, Magic Missile, Shield, Gust of Wind, Misty Step, Shatter, Fly, Lightning Bolt</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -324,7 +324,7 @@
 			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or ranged 20 ft./60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
 			<attack>Dagger|6|1d4+4</attack>
 		</action>
-		<spells>fire bolt, prestidigitation, shocking grasp, longstrider, magic missile, shield, thunderwave, magic weapon, misty step</spells>
+		<spells>Fire Bolt, Prestidigitation, Shocking Grasp, Longstrider, Magic Missile, Shield, Thunderwave, Magic Weapon, Misty Step</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -364,7 +364,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 7 (1d10 + 2) bludgeoning damage.</text>
 			<attack>Halberd|5|1d10+2</attack>
 		</action>
-		<spells>light, sacred flame, thaumaturgy, command, cure wounds, healing word, sanctuary, calm emotions, hold person, spiritual weapon, mass healing word, spirit guardians</spells>
+		<spells>Light, Sacred Flame, Thaumaturgy, Command, Cure Wounds, Healing Word, Sanctuary, Calm Emotions, Hold Person, Spiritual Weapon, Mass Healing Word, Spirit Guardians</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -448,7 +448,7 @@
 			<attack>Shortsword|5|1d6+3</attack>
 			<attack>Shortsword vs medium or larger|5|1d6+3+1d6</attack>
 		</action>
-		<spells>mage hand, minor illusion, prestidigitation, ray of frost, charm person, color spray, disguise self, longstrider</spells>
+		<spells>Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Charm Person, Color Spray, Disguise Self, Longstrider</spells>
 		<slots>3,0,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -562,7 +562,7 @@
 			<attack>One Handed|5|1d6+2</attack>
 			<attack>Two Handed|5|1d8+2</attack>
 		</action>
-		<spells>druidcraft, guidance, poison spray, cure wounds, entangle, healing word, thunderwave, barkskin, beast sense, spike growth, plant growth, water walk</spells>
+		<spells>Druidcraft, Guidance, Poison Spray, Cure Wounds, Entangle, Healing Word, Thunderwave, Barkskin, Beast Sense, Spike Growth, Plant Growth, Water Walk</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -610,7 +610,7 @@
 			<name>Illusory Self (Recharges on a Short or Long Rest)</name>
 			<text>When a creature Rath can see makes an attack roll against him, he can interpose an illusory duplicate between the attacker and him. The attack automatically misses Rath, then the illusion dissipates.</text>
 		</reaction>
-		<spells>fire bolt, minor illusion, prestidigitation, shocking grasp, chromatic orb, color spray, mage armor, magic missile, detect thoughts, mirror image, phantasmal force, counterspell, fireball, major image, confusion, greater invisibility, mislead, seeming, globe of invulnerability</spells>
+		<spells>Fire Bolt, Minor Illusion, Prestidigitation, Shocking Grasp, Chromatic Orb, Color Spray, Mage Armor, Magic Missile, Detect Thoughts, Mirror Image, Phantasmal Force, Counterspell, Fireball, Major Image, Confusion, Greater Invisibility, Mislead, Seeming, Globe of Invulnerability</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -740,7 +740,7 @@
 			<attack>One Handed|5|1d6+2</attack>
 			<attack>Two Handed|5|1d8+2</attack>
 		</action>
-		<spells>guidance, resistance, thaumaturgy, command, cure wounds, healing word, inflict wounds, blindness/deafness, lesser restoration, spiritual weapon, dispel magic, mass healing word, sending, death ward, freedom of movement, insect plague</spells>
+		<spells>Guidance, Resistance, Thaumaturgy, Command, Cure Wounds, Healing Word, Inflict Wounds, Blindness/Deafness, Lesser Restoration, Spiritual Weapon, Dispel Magic, Mass Healing Word, Sending, Death Ward, Freedom of Movement, Insect Plague</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 </compendium>

--- a/Bestiary/Lost Mine of Phandelver.xml
+++ b/Bestiary/Lost Mine of Phandelver.xml
@@ -34,7 +34,7 @@
 			<attack>One Handed|1|1d6-1</attack>
 			<attack>Two Handed|1|1d8-1</attack>
 		</action>
-		<spells>light, mage hand, shocking grasp, charm person, magic missile, hold person, misty step</spells>
+		<spells>Light, Mage Hand, Shocking Grasp, Charm Person, Magic Missile, Hold Person, Misty Step</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -126,7 +126,7 @@
 			<attack>One Handed|1|1d6-1+1d6</attack>
 			<attack>Two Handed|1|1d8-1+1d6</attack>
 		</action>
-		<spells>dancing lights, darkness, faerie fire, mage hand, ray of frost, shocking grasp, mage armor, magic missile, shield, invisibility, suggestion</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire, Mage Hand, Ray of Frost, Shocking Grasp, Mage Armor, Magic Missile, Shield, Invisibility, Suggestion</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Monster Manual.xml
+++ b/Bestiary/Monster Manual.xml
@@ -187,7 +187,7 @@
 			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage.</text>
 			<attack>Club|2|1d4</attack>
 		</action>
-		<spells>light, sacred flame, thaumaturgy, bless, cure wounds, sanctuary</spells>
+		<spells>Light, Sacred Flame, Thaumaturgy, Bless, Cure Wounds, Sanctuary</spells>
 		<description>Acolytes are junior members of the clergy, usually answerable to a priest. They perform a variety of functions in a temple and are granted minor spellcasting power by their deities.</description>
 		<slots>3,0,0,0,0,0,0,0,0</slots>
 	</monster>
@@ -1817,7 +1817,7 @@
 			<name>Cast a Spell (Costs 3 Actions)</name>
 			<text>The sphinx casts a spell from its list of prepared spells, using a spell slot as normal.</text>
 		</legendary>
-		<spells>sacred flame, spare the dying, thaumaturgy, command, detect evil and good, detect magic, lesser restoration, zone of truth, dispel magic, tongues, banishment, freedom of movement, flame strike, greater restoration, heroes' feast</spells>
+		<spells>Sacred Flame, Spare the Dying, Thaumaturgy, Command, Detect Evil and Good, Detect Magic, Lesser Restoration, Zone of Truth, Dispel Magic, Tongues, Banishment, Freedom of Movement, Flame Strike, Greater Restoration, Heroes' Feast</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -2008,7 +2008,7 @@
 			<text>An arcanaloth has a 40 percent chance of summoning one arcanaloth.</text>
 			<text>A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it.</text>
 		</action>
-		<spells>alter self, darkness, heat metal, invisibility, magic missile, fire bolt, mage hand, minor illusion, prestidigitation, detect magic, identify, shield, Tenser's floating disk, detect thoughts, mirror image, phantasmal force, suggestion, counterspell, fear, fireball, banishment, dimension door, contact other plane, hold monster, chain lightning, finger of death, mind blank</spells>
+		<spells>Alter Self, Darkness, Heat Metal, Invisibility, Magic Missile, Fire Bolt, Mage Hand, Minor Illusion, Prestidigitation, Detect Magic, Identify, Shield, Tenser's Floating Disk, Detect Thoughts, Mirror Image, Phantasmal Force, Suggestion, Counterspell, Fear, Fireball, Banishment, Dimension Door, Contact Other Plane, Hold Monster, Chain Lightning, Finger of Death, Mind Blank</spells>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
 	</monster>
 	<monster>
@@ -2056,7 +2056,7 @@
 			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|6|1d4+2</attack>
 		</action>
-		<spells>fire bolt, light, mage hand, prestidigitation, shocking grasp, detect magic, identify, mage armor, magic missile, detect thoughts, mirror image, misty step, counterspell, fly, lightning bolt, banishment, fire shield, stoneskin, cone of cold, scrying, wall of force, globe of invulnerability, teleport, mind blank, time stop</spells>
+		<spells>Fire Bolt, Light, Mage Hand, Prestidigitation, Shocking Grasp, Detect Magic, Identify, Mage Armor, Magic Missile, Detect Thoughts, Mirror Image, Misty Step, Counterspell, Fly, Lightning Bolt, Banishment, Fire Shield, Stoneskin, Cone of Cold, Scrying, Wall of Force, Globe of Invulnerability, Teleport, Mind Blank, Time Stop</spells>
 		<slots>4,3,3,3,3,1,1,1,1</slots>
 	</monster>
 	<monster>
@@ -2619,7 +2619,7 @@
 			<text>A barlgura has a 30 percent chance of summoning one barlgura.</text>
 			<text>A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>entangle, phantasmal force, disguise self, invisibility</spells>
+		<spells>Entangle, Phantasmal Force, Disguise Self, Invisibility</spells>
 	</monster>
 	<monster>
 		<name>Basilisk</name>
@@ -3331,7 +3331,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 10 ft., one creature. Hit: 10 (2d6 + 3) piercing damage plus 10 (3d6) poison damage.</text>
 			<attack>Bite|5|2d6+3+3d6</attack>
 		</action>
-		<spells>mending, sacred flame, thaumaturgy, command, shield of faith, calm emotions, hold person, bestow curse</spells>
+		<spells>Mending, Sacred Flame, Thaumaturgy, Command, Shield of Faith, Calm Emotions, Hold Person, Bestow Curse</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3368,7 +3368,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 10 ft., one creature. Hit: 10 (2d6 + 3) piercing damage plus 10 (3d6) poison damage.</text>
 			<attack>Bite|5|2d6+3+3d6</attack>
 		</action>
-		<spells>mage hand, minor illusion, ray of frost, charm person, sleep, detect thoughts, hold person, lightning bolt</spells>
+		<spells>Mage Hand, Minor Illusion, Ray of Frost, Charm Person, Sleep, Detect Thoughts, Hold Person, Lightning Bolt</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3706,7 +3706,7 @@
 			<name>Fiendish Charm</name>
 			<text>One humanoid the cambion can see within 30 ft. of it must succeed on a DC 14 Wisdom saving throw or be magically charmed for 1 day. The charmed target obeys the cambion's spoken commands. If the target suffers any harm from the cambion or another creature or receives a suicidal command from the cambion, the target can repeat the saving throw, ending the effect on itself on a success. If a target's saving throw is successful, or if the effect ends for it, the creature is immune to the cambion's Fiendish Charm for the next 24 hours.</text>
 		</action>
-		<spells>alter self, command, detect magic, plane shift</spells>
+		<spells>Alter Self, Command, Detect Magic, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Camel</name>
@@ -4235,7 +4235,7 @@
 			<text>Ranged Weapon Attack: +12 to hit, range 60/240 ft., one target. Hit: 30 (4d10 + 8) bludgeoning damage.</text>
 			<attack>Rock|12|4d10+8</attack>
 		</action>
-		<spells>detect magic, fog cloud, light, feather fall, fly, misty step, telekinesis, control weather, gaseous form</spells>
+		<spells>Detect Magic, Fog Cloud, Light, Feather Fall, Fly, Misty Step, Telekinesis, Control Weather, Gaseous Form</spells>
 	</monster>
 	<monster>
 		<name>Cockatrice</name>
@@ -4401,7 +4401,7 @@
 			<text>The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).</text>
 			<text>In a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form.</text>
 		</action>
-		<spells>detect evil and good, detect magic, detect thoughts, bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield, dream, greater restoration, scrying</spells>
+		<spells>Detect Evil and Good, Detect Magic, Detect Thoughts, Bless, Create Food and Water, Cure Wounds, Lesser Restoration, Protection from Poison, Sanctuary, Shield, Dream, Greater Restoration, Scrying</spells>
 	</monster>
 	<monster>
 		<name>Crab</name>
@@ -4530,7 +4530,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>light, sacred flame, thaumaturgy, command, inflict wounds, shield of faith, hold person, spiritual weapon</spells>
+		<spells>Light, Sacred Flame, Thaumaturgy, Command, Inflict Wounds, Shield of Faith, Hold Person, Spiritual Weapon</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -4663,7 +4663,7 @@
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 20 (4d6 + 6) bludgeoning damage. If the target is a Huge or smaller creature, it must succeed on a DC 18 Strength check or be knocked prone.</text>
 			<attack>Maul|10|4d6+6</attack>
 		</action>
-		<spells>detect evil and good, detect magic, stone shape, passwall, move earth, tongues, conjure elemental, gaseous form, invisibility, phantasmal killer, plane shift, wall of stone</spells>
+		<spells>Detect Evil and Good, Detect Magic, Stone Shape, Passwall, Move Earth, Tongues, Conjure Elemental, Gaseous Form, Invisibility, Phantasmal Killer, Plane Shift, Wall of Stone</spells>
 	</monster>
 	<monster>
 		<name>Darkmantle</name>
@@ -4798,7 +4798,7 @@
 			<name>Parry</name>
 			<text>The death knight adds 6 to its AC against one melee attack that would hit it. To do so, the death knight must see the attacker and be wielding a melee weapon.</text>
 		</reaction>
-		<spells>command, compelled duel, searing smite, hold person, magic weapon, dispel magic, elemental weapon, banishment, staggering smite, destructive wave</spells>
+		<spells>Command, Compelled Duel, Searing Smite, Hold Person, Magic Weapon, Dispel Magic, Elemental Weapon, Banishment, Staggering Smite, Destructive Wave</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -4871,7 +4871,7 @@
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage plus 7 (2d6) necrotic damage.</text>
 			<attack>Greatsword|9|2d6+5+2d6</attack>
 		</action>
-		<spells>detect magic, detect thoughts, invisibility, mage hand, major image, fear, fireball, fly, tongues, cloudkill, plane shift</spells>
+		<spells>Detect Magic, Detect Thoughts, Invisibility, Mage Hand, Major Image, Fear, Fireball, Fly, Tongues, Cloudkill, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Death Tyrant</name>
@@ -4971,7 +4971,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success</text>
 			<attack>Poisoned Dart|4|1d4+2</attack>
 		</action>
-		<spells>nondetection, blindness/deafness, blur, disguise self</spells>
+		<spells>Nondetection, Blindness/Deafness, Blur, Disguise Self</spells>
 	</monster>
 	<monster>
 		<name>Deer</name>
@@ -5110,7 +5110,7 @@
 			<text>The deva magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the deva's choice).</text>
 			<text>In a new form, the deva retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and special senses are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks.</text>
 		</action>
-		<spells>detect evil and good, commune, raise dead</spells>
+		<spells>Detect Evil and Good, Commune, Raise Dead</spells>
 	</monster>
 	<monster>
 		<name>Dire Wolf</name>
@@ -5235,7 +5235,7 @@
 			<text>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell). Any creature but the djinni that enters the whirlwind must succeed on a DC 18 Strength saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it.</text>
 			<text>A creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a DC 18 Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind.</text>
 		</action>
-		<spells>detect evil and good, detect magic, thunderwave, create food and water, tongues, wind walk, conjure elemental, creation, gaseous form, invisibility, major image, plane shift</spells>
+		<spells>Detect Evil and Good, Detect Magic, Thunderwave, Create Food and Water, Tongues, Wind Walk, Conjure Elemental, Creation, Gaseous Form, Invisibility, Major Image, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Doppelganger</name>
@@ -5461,7 +5461,7 @@
 			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage.</text>
 			<attack>Longbow|6|1d8+3+1d8</attack>
 		</action>
-		<spells>dancing lights, darkness, faerie fire</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire</spells>
 	</monster>
 	<monster>
 		<name>Drider Spellcaster</name>
@@ -5534,7 +5534,7 @@
 			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage.</text>
 			<attack>Longbow|6|1d8+3+1d8</attack>
 		</action>
-		<spells>dancing lights, darkness, faerie fire, poison spray, thaumaturgy, bane, detect magic, sanctuary, hold person, silence, clairvoyance, dispel magic, divination, freedom of movement</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire, Poison Spray, Thaumaturgy, Bane, Detect Magic, Sanctuary, Hold Person, Silence, Clairvoyance, Dispel Magic, Divination, Freedom of Movement</spells>
 		<slots>4,3,3,2,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -5581,7 +5581,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake.</text>
 			<attack>Hand Crossbow|4|1d6+2</attack>
 		</action>
-		<spells>dancing lights, darkness, faerie fire</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire</spells>
 	</monster>
 	<monster>
 		<name>Drow Elite Warrior</name>
@@ -5636,7 +5636,7 @@
 			<name>Parry</name>
 			<text>The drow adds 3 to its AC against one melee attack that would hit it. To do so, the drow must see the attacker and be wielding a melee weapon.</text>
 		</reaction>
-		<spells>dancing lights, darkness, faerie fire, levitate</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire, Levitate</spells>
 	</monster>
 	<monster>
 		<name>Drow Mage</name>
@@ -5692,7 +5692,7 @@
 			<name>Summon Demon (1/Day)</name>
 			<text>The drow magically summons a quasit, or attempts to summon a shadow demon with a 50 percent chance of success. The summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>dancing lights, darkness, faerie fire, levitate, mage hand, minor illusion, poison spray, ray of frost, mage armor, magic missile, shield, witch bolt, alter self, misty step, web, fly, lightning bolt, Evard's black tentacles, greater invisibility, cloudkill</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire, Levitate, Mage Hand, Minor Illusion, Poison Spray, Ray of Frost, Mage Armor, Magic Missile, Shield, Witch Bolt, Alter Self, Misty Step, Web, Fly, Lightning Bolt, Evard's Black Tentacles, Greater Invisibility, Cloudkill</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -5753,7 +5753,7 @@
 			<name>Summon Demon (1/Day)</name>
 			<text>The drow attempts to magically summon a yochlol with a 30 percent chance of success. If the attempt fails, the drow takes 5 (1d10) psychic damage. Otherwise, the summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>dancing lights, darkness, faerie fire, levitate, guidance, poison spray, resistance, spare the dying, thaumaturgy, animal friendship, cure wounds, detect poison and disease, ray of sickness, lesser restoration, protection from poison, web, conjure animals, dispel magic, divination, freedom of movement, insect plague, mass cure wounds</spells>
+		<spells>Dancing Lights, Darkness, Faerie Fire, Levitate, Guidance, Poison Spray, Resistance, Spare the Dying, Thaumaturgy, Animal Friendship, Cure Wounds, Detect Poison and Disease, Ray of Sickness, Lesser Restoration, Protection from Poison, Web, Conjure Animals, Dispel Magic, Divination, Freedom of Movement, Insect Plague, Mass Cure Wounds</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -5788,7 +5788,7 @@
 			<attack>Quarterstaff|2|1d6</attack>
 			<attack>Shillelagh|4|1d8+2</attack>
 		</action>
-		<spells>druidcraft, produce flame, shillelagh, entangle, longstrider, speak with animals, thunderwave, animal messenger, barkskin</spells>
+		<spells>Druidcraft, Produce Flame, Shillelagh, Entangle, Longstrider, Speak with Animals, Thunderwave, Animal Messenger, Barkskin</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -5842,7 +5842,7 @@
 			<text>Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.</text>
 			<text>The dryad can have no more than one humanoid and up to three beasts charmed at a time.</text>
 		</action>
-		<spells>druidcraft, entangle, goodberry, barkskin, pass without trace, shillelagh</spells>
+		<spells>Druidcraft, Entangle, Goodberry, Barkskin, Pass without Trace, Shillelagh</spells>
 	</monster>
 	<monster>
 		<name>Duergar</name>
@@ -5980,7 +5980,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>sleep</spells>
+		<spells>Sleep</spells>
 	</monster>
 	<monster>
 		<name>Eagle</name>
@@ -6107,7 +6107,7 @@
 			<text>Ranged Spell Attack: +7 to hit, range 120 ft., one target. Hit: 17 (5d6) fire damage.</text>
 			<attack>Flame|7|5d6</attack>
 		</action>
-		<spells>detect magic, enlarge/reduce, tongues, conjure elemental, gaseous form, invisibility, major image, plane shift, wall of fire</spells>
+		<spells>Detect Magic, Enlarge/Reduce, Tongues, Conjure Elemental, Gaseous Form, Invisibility, Major Image, Plane Shift, Wall of Fire</spells>
 	</monster>
 	<monster>
 		<name>Elephant</name>
@@ -6236,7 +6236,7 @@
 			<name>Trembling Strike (Costs 2 Actions)</name>
 			<text>The empyrean strikes the ground with its maul, triggering an earth tremor. All other creatures on the ground within 60 feet of the empyrean must succeed on a DC 25 Strength saving throw or be knocked prone.</text>
 		</legendary>
-		<spells>greater restoration, pass without trace, water breathing, water walk, commune, dispel evil and good, earthquake, fire storm, plane shift</spells>
+		<spells>Greater Restoration, Pass without Trace, Water Breathing, Water Walk, Commune, Dispel Evil and Good, Earthquake, Fire Storm, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Erinyes</name>
@@ -6452,7 +6452,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>color spray, dancing lights, mage hand, major image, minor illusion, mirror image, suggestion</spells>
+		<spells>Color Spray, Dancing Lights, Mage Hand, Major Image, Minor Illusion, Mirror Image, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Faerie Dragon (Green)</name>
@@ -6515,7 +6515,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>color spray, dancing lights, mage hand, minor illusion, mirror image, suggestion</spells>
+		<spells>Color Spray, Dancing Lights, Mage Hand, Minor Illusion, Mirror Image, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Faerie Dragon (Indigo)</name>
@@ -6578,7 +6578,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>color spray, dancing lights, hallucinatory terrain, mage hand, major image, minor illusion, mirror image, suggestion</spells>
+		<spells>Color Spray, Dancing Lights, Hallucinatory Terrain, Mage Hand, Major Image, Minor Illusion, Mirror Image, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Faerie Dragon (Orange)</name>
@@ -6641,7 +6641,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>color spray, dancing lights, mage hand, minor illusion</spells>
+		<spells>Color Spray, Dancing Lights, Mage Hand, Minor Illusion</spells>
 	</monster>
 	<monster>
 		<name>Faerie Dragon (Red)</name>
@@ -6704,7 +6704,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>dancing lights, mage hand, minor illusion</spells>
+		<spells>Dancing Lights, Mage Hand, Minor Illusion</spells>
 	</monster>
 	<monster>
 		<name>Faerie Dragon (Violet)</name>
@@ -6767,7 +6767,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>color spray, dancing lights, hallucinatory terrain, mage hand, major image, minor illusion, mirror image, polymorph, suggestion</spells>
+		<spells>Color Spray, Dancing Lights, Hallucinatory Terrain, Mage Hand, Major Image, Minor Illusion, Mirror Image, Polymorph, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Faerie Dragon (Yellow)</name>
@@ -6830,7 +6830,7 @@
 			<text>1-4. The target takes no action or bonus action and uses all of its movement to move in a random direction.</text>
 			<text>5-6. The target doesn't move, and the only thing it can do on its turn is make a DC 11 Wisdom saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>color spray, dancing lights, mage hand, minor illusion, mirror image</spells>
+		<spells>Color Spray, Dancing Lights, Mage Hand, Minor Illusion, Mirror Image</spells>
 	</monster>
 	<monster>
 		<name>Fire Elemental</name>
@@ -7016,7 +7016,7 @@
 			<text>Ranged Spell Attack: +5 to hit, range 30 ft., one target. Hit: 10 (3d6) fire damage.</text>
 			<attack>Fire Ray|5|3d6</attack>
 		</action>
-		<spells>mage hand, magic missile, shield, blur, flaming sphere, fireball</spells>
+		<spells>Mage Hand, Magic Missile, Shield, Blur, Flaming Sphere, Fireball</spells>
 		<slots>3,2,1,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -8615,7 +8615,7 @@
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage plus 10 (3d6) psychic damage. This is a magic weapon attack. On a critical hit against a target in an astral body (as with the astral projection spell), the githyanki can cut the silvery cord that tethers the target to its material body, instead of dealing damage.</text>
 			<attack>Silver Greatsword|9|2d6+6+3d6</attack>
 		</action>
-		<spells>mage hand, jump, misty step, nondetection, tongues, plane shift, telekinesis</spells>
+		<spells>Mage Hand, Jump, Misty Step, Nondetection, Tongues, Plane Shift, Telekinesis</spells>
 	</monster>
 	<monster>
 		<name>Githyanki Warrior</name>
@@ -8652,7 +8652,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage plus 7 (2d6) psychic damage.</text>
 			<attack>Greatsword|4|2d6+2+2d6</attack>
 		</action>
-		<spells>mage hand, jump, misty step, nondetection</spells>
+		<spells>Mage Hand, Jump, Misty Step, Nondetection</spells>
 	</monster>
 	<monster>
 		<name>Githzerai Monk</name>
@@ -8694,7 +8694,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) bludgeoning damage plus 9 (2d8) psychic damage. This is a magic weapon attack.</text>
 			<attack>Unarmed Strike|4|1d8+2+2d8</attack>
 		</action>
-		<spells>mage hand, feather fall, jump, see invisibility, shield</spells>
+		<spells>Mage Hand, Feather Fall, Jump, See Invisibility, Shield</spells>
 	</monster>
 	<monster>
 		<name>Githzerai Zerth</name>
@@ -8736,7 +8736,7 @@
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage plus 13 (3d8) psychic damage. This is a magic weapon attack.</text>
 			<attack>Unarmed Strike|7|2d6+4+3d8</attack>
 		</action>
-		<spells>mage hand, feather fall, jump, see invisibility, shield</spells>
+		<spells>Mage Hand, Feather Fall, Jump, See Invisibility, Shield</spells>
 	</monster>
 	<monster>
 		<name>Glabrezu</name>
@@ -8791,7 +8791,7 @@
 			<text>A glabrezu has a 30 percent chance of summoning 1d3 vrocks, 1d2 hezrous, or one glabrezu.</text>
 			<text>A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>darkness, detect magic, dispel magic, confusion, fly, power word stun</spells>
+		<spells>Darkness, Detect Magic, Dispel Magic, Confusion, Fly, Power Word Stun</spells>
 	</monster>
 	<monster>
 		<name>Gladiator</name>
@@ -9369,7 +9369,7 @@
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage.</text>
 			<attack>Greatsword|7|2d6+3</attack>
 		</action>
-		<spells>detect magic, detect thoughts, invisibility, mage hand, major image, fear, fly, fireball, tongues, plane shift</spells>
+		<spells>Detect Magic, Detect Thoughts, Invisibility, Mage Hand, Major Image, Fear, Fly, Fireball, Tongues, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Green Dragon Wyrmling</name>
@@ -9478,7 +9478,7 @@
 			<name>Invisible Passage</name>
 			<text>The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her.</text>
 		</action>
-		<spells>dancing lights, minor illusion, vicious mockery, identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Dancing Lights, Minor Illusion, Vicious Mockery, Identify, Ray of Sickness, Hold Person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Green Slaad</name>
@@ -9551,7 +9551,7 @@
 			<text>Ranged Spell Attack: +4 to hit, range 60 ft., one target. Hit: 10 (3d6) fire damage. The fire ignites flammable objects that aren 't being worn or carried.</text>
 			<attack>Hurl Flame|4|3d6</attack>
 		</action>
-		<spells>detect magic, detect thoughts, mage hand, fear, invisibility, fireball</spells>
+		<spells>Detect Magic, Detect Thoughts, Mage Hand, Fear, Invisibility, Fireball</spells>
 	</monster>
 	<monster>
 		<name>Grell</name>
@@ -9822,7 +9822,7 @@
 			<text>Ranged Weapon Attack: +8 to hit, range 15/30 ft., one creature. Hit: The target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one.</text>
 			<attack>Spit Poison|8|10d8</attack>
 		</action>
-		<spells>mending, sacred flame, thaumaturgy, command, cure wounds, shield of faith, calm emotions, hold person, bestow curse, clairvoyance, banishment, freedom of movement, flame strike, geas, true seeing</spells>
+		<spells>Mending, Sacred Flame, Thaumaturgy, Command, Cure Wounds, Shield of Faith, Calm Emotions, Hold Person, Bestow Curse, Clairvoyance, Banishment, Freedom of Movement, Flame Strike, Geas, True Seeing</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -9887,7 +9887,7 @@
 			<name>Cast a Spell (Costs 3 Actions)</name>
 			<text>The sphinx casts a spell from its list of prepared spells, using a spell slot as normal.</text>
 		</legendary>
-		<spells>mage hand, minor illusion, prestidigitation, detect magic, identify, shield, darkness, locate object, suggestion, dispel magic, remove curse, tongues, banishment, greater invisibility, legend lore</spells>
+		<spells>Mage Hand, Minor Illusion, Prestidigitation, Detect Magic, Identify, Shield, Darkness, Locate Object, Suggestion, Dispel Magic, Remove Curse, Tongues, Banishment, Greater Invisibility, Legend Lore</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -10774,7 +10774,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>fog cloud</spells>
+		<spells>Fog Cloud</spells>
 	</monster>
 	<monster>
 		<name>Imp</name>
@@ -11393,7 +11393,7 @@
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) bludgeoning damage.</text>
 			<attack>Unarmed Strike|6|1d4+3</attack>
 		</action>
-		<spells>guidance, sacred flame, thaumaturgy, detect magic, sanctuary, shield of faith, hold person, spiritual weapon, spirit guardians, tongues, control water, divination, mass cure wounds, scrying</spells>
+		<spells>Guidance, Sacred Flame, Thaumaturgy, Detect Magic, Sanctuary, Shield of Faith, Hold Person, Spiritual Weapon, Spirit Guardians, Tongues, Control Water, Divination, Mass Cure Wounds, Scrying</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -11507,7 +11507,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 10 ft., one target. Hit: 5 (1d6 + 2) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 14). Until this grapple ends, the kuo-toa can't use its pincer staff on another target.</text>
 			<attack>Pincer Staff|4|1d6+2</attack>
 		</action>
-		<spells>sacred flame, thaumaturgy, bane, shield of faith</spells>
+		<spells>Sacred Flame, Thaumaturgy, Bane, Shield of Faith</spells>
 		<slots>3,0,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -11555,7 +11555,7 @@
 			<name>Intoxicating Touch</name>
 			<text>Melee Spell Attack: +5 to hit, reach 5 ft., one creature. Hit: The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks.</text>
 		</action>
-		<spells>disguise self, major image, charm person, mirror image, scrying, suggestion, geas</spells>
+		<spells>Disguise Self, Major Image, Charm Person, Mirror Image, Scrying, Suggestion, Geas</spells>
 	</monster>
 	<monster>
 		<name>Lemure</name>
@@ -11665,7 +11665,7 @@
 			<text>Each non-undead creature within 20 feet of the lich must make a DC 18 Constitution saving throw against this magic, taking 21 (6d6) necrotic damage on a failed save, or half as much damage on a successful one.</text>
 			<attack>Disrupt Life||6d6</attack>
 		</legendary>
-		<spells>mage hand, prestidigitation, ray of frost, detect magic, magic missile, shield, thunderwave, detect thoughts, invisibility, Melf's acid arrow, mirror image, animate dead, counterspell, dispel magic, fireball, blight, dimension door, cloudkill, scrying, disintegrate, globe of invulnerability, finger of death, plane shift, dominate monster, power word stun, power word kill</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Detect Magic, Magic Missile, Shield, Thunderwave, Detect Thoughts, Invisibility, Melf's Acid Arrow, Mirror Image, Animate Dead, Counterspell, Dispel Magic, Fireball, Blight, Dimension Door, Cloudkill, Scrying, Disintegrate, Globe of Invulnerability, Finger of Death, Plane Shift, Dominate Monster, Power Word Stun, Power Word Kill</spells>
 		<slots>4,3,3,3,3,1,1,1,1</slots>
 	</monster>
 	<monster>
@@ -11886,7 +11886,7 @@
 			<name>Change Shape (Recharges after a Short or Long Rest)</name>
 			<text>The lizardfolk magically polymorphs into a crocodile, remaining in that form for up to 1 hour. It can revert to its true form as a bonus action. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.</text>
 		</action>
-		<spells>druidcraft, produce flame, thorn whip, entangle, fog cloud, heat metal, spike growth, conjure animals, plant growth</spells>
+		<spells>Druidcraft, Produce Flame, Thorn Whip, Entangle, Fog Cloud, Heat Metal, Spike Growth, Conjure Animals, Plant Growth</spells>
 	</monster>
 	<monster>
 		<name>Mage</name>
@@ -11923,7 +11923,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|5|1d4+2</attack>
 		</action>
-		<spells>fire bolt, light, mage hand, prestidigitation, detect magic, mage armor, magic missile, shield, misty step, suggestion, counterspell, fireball, fly, greater invisibility, ice storm, cone of cold</spells>
+		<spells>Fire Bolt, Light, Mage Hand, Prestidigitation, Detect Magic, Mage Armor, Magic Missile, Shield, Misty Step, Suggestion, Counterspell, Fireball, Fly, Greater Invisibility, Ice Storm, Cone of Cold</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -11976,7 +11976,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>heat metal</spells>
+		<spells>Heat Metal</spells>
 	</monster>
 	<monster>
 		<name>Magmin</name>
@@ -12177,7 +12177,7 @@
 			<text>The marid magically shoots water in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw. On a failure, a target takes 21 (6d6) bludgeoning damage and, if it is Huge or smaller, is pushed up to 20 feet away from the marid and knocked prone. On a success, a target takes half the bludgeoning damage, but is neither pushed nor knocked prone.</text>
 			<attack>Water Jet||6d6</attack>
 		</action>
-		<spells>create or destroy water, detect evil and good, detect magic, fog cloud, purify food and drink, tongues, water breathing, water walk, conjure elemental, control water, gaseous form, invisibility, plane shift</spells>
+		<spells>Create or Destroy Water, Detect Evil and Good, Detect Magic, Fog Cloud, Purify Food and Drink, Tongues, Water Breathing, Water Walk, Conjure Elemental, Control Water, Gaseous Form, Invisibility, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Marilith</name>
@@ -12451,7 +12451,7 @@
 			<text>A mezzoloth has a 30 percent chance of summoning one mezzoloth.</text>
 			<text>A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it.</text>
 		</action>
-		<spells>darkness, dispel magic, cloudkill</spells>
+		<spells>Darkness, Dispel Magic, Cloudkill</spells>
 	</monster>
 	<monster>
 		<name>Mimic</name>
@@ -12548,7 +12548,7 @@
 			<text>The mind flayer magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 15 Intelligence saving throw or take 22 (4d8 + 4) psychic damage and be stunned for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 			<attack>Mind Blast||4d8+4</attack>
 		</action>
-		<spells>detect thoughts, levitate, dominate monster, plane shift</spells>
+		<spells>Detect Thoughts, Levitate, Dominate Monster, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Mind Flayer Arcanist</name>
@@ -12607,7 +12607,7 @@
 			<text>The mind flayer magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 15 Intelligence saving throw or take 22 (4d8 + 4) psychic damage and be stunned for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 			<attack>Mind Blast||4d8+4</attack>
 		</action>
-		<spells>detect thoughts, levitate, dominate monster, plane shift, blade ward, dancing lights, mage hand, shocking grasp, detect magic, disguise self, shield, sleep, blur, invisibility, ray of enfeeblement, clairvoyance, lightning bolt, sending, confusion, hallucinatory terrain, telekinesis, wall of force</spells>
+		<spells>Detect Thoughts, Levitate, Dominate Monster, Plane Shift, Blade Ward, Dancing Lights, Mage Hand, Shocking Grasp, Detect Magic, Disguise Self, Shield, Sleep, Blur, Invisibility, Ray of Enfeeblement, Clairvoyance, Lightning Bolt, Sending, Confusion, Hallucinatory Terrain, Telekinesis, Wall of Force</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -12918,7 +12918,7 @@
 			<name>Whirlwind of Sand (Costs 2 Actions)</name>
 			<text>The mummy lord magically transforms into a whirlwind of sand, moves up to 60 feet, and reverts to its normal form. While in whirlwind form, the mummy lord is immune to all damage, and it can't be grappled, petrified, knocked prone, restrained, or stunned. Equipment worn or carried by the mummy lord remain in its possession.</text>
 		</legendary>
-		<spells>sacred flame, thaumaturgy, command, guiding bolt, shield of faith, hold person, silence, spiritual weapon, animate dead, dispel magic, divination, guardian of faith, contagion, insect plague, harm</spells>
+		<spells>Sacred Flame, Thaumaturgy, Command, Guiding Bolt, Shield of Faith, Hold Person, Silence, Spiritual Weapon, Animate Dead, Dispel Magic, Divination, Guardian of Faith, Contagion, Insect Plague, Harm</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -13213,7 +13213,7 @@
 			<name>Nightmare Haunting (1/Day)</name>
 			<text>While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A protection from evil and good spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the greater restoration spell or similar magic.</text>
 		</action>
-		<spells>detect magic, magic missile, plane shift, ray of enfeeblement, sleep, identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Detect Magic, Magic Missile, Plane Shift, Ray of Enfeeblement, Sleep, Identify, Ray of Sickness, Hold Person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Nightmare</name>
@@ -13384,7 +13384,7 @@
 			<text>A nycaloth has a 50 percent chance of summoning 1d4 mezzoloths or one nycaloth.</text>
 			<text>A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it.</text>
 		</action>
-		<spells>darkness, detect magic, dispel magic, invisibility, mirror image</spells>
+		<spells>Darkness, Detect Magic, Dispel Magic, Invisibility, Mirror Image</spells>
 	</monster>
 	<monster>
 		<name>Ochre Jelly</name>
@@ -13582,7 +13582,7 @@
 			<name>Change Shape</name>
 			<text>The oni magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the oni dies, it reverts to its true form, and its glaive reverts to its normal size.</text>
 		</action>
-		<spells>darkness, invisibility, charm person, cone of cold, gaseous form, sleep</spells>
+		<spells>Darkness, Invisibility, Charm Person, Cone of Cold, Gaseous Form, Sleep</spells>
 	</monster>
 	<monster>
 		<name>Orc</name>
@@ -13660,7 +13660,7 @@
 			<attack>One Handed|5|1d6+3+1d8</attack>
 			<attack>Two Handed|5|2d8+3</attack>
 		</action>
-		<spells>guidance, resistance, thaumaturgy, bless, command, augury, spiritual weapon</spells>
+		<spells>Guidance, Resistance, Thaumaturgy, Bless, Command, Augury, Spiritual Weapon</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -14153,7 +14153,7 @@
 			<text>Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 24 (3d10 + 8) bludgeoning damage.</text>
 			<attack>Tail|14|3d10+8</attack>
 		</action>
-		<spells>detect magic, fireball, hold monster, wall of fire</spells>
+		<spells>Detect Magic, Fireball, Hold Monster, Wall of Fire</spells>
 	</monster>
 	<monster>
 		<name>Pixie</name>
@@ -14188,7 +14188,7 @@
 			<name>Superior Invisibility</name>
 			<text>The pixie magically turns invisible until its concentration ends (as if concentrating on a spell). Any equipment the pixie wears or carries is invisible with it.</text>
 		</action>
-		<spells>druidcraft, confusion, dancing lights, detect evil and good, detect thoughts, dispel magic, entangle, fly, phantasmal force, polymorph, sleep</spells>
+		<spells>Druidcraft, Confusion, Dancing Lights, Detect Evil and Good, Detect Thoughts, Dispel Magic, Entangle, Fly, Phantasmal Force, Polymorph, Sleep</spells>
 	</monster>
 	<monster>
 		<name>Planetar</name>
@@ -14245,7 +14245,7 @@
 			<name>Healing Touch (4/Day)</name>
 			<text>The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness.</text>
 		</action>
-		<spells>detect evil and good, invisibility, blade barrier, dispel evil and good, flame strike, raise dead, commune, control weather, insect plague</spells>
+		<spells>Detect Evil and Good, Invisibility, Blade Barrier, Dispel Evil and Good, Flame Strike, Raise Dead, Commune, Control Weather, Insect Plague</spells>
 	</monster>
 	<monster>
 		<name>Plesiosaurus</name>
@@ -14442,7 +14442,7 @@
 			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage.</text>
 			<attack>Mace|2|1d6</attack>
 		</action>
-		<spells>light, sacred flame, thaumaturgy, cure wounds, guiding bolt, sanctuary, lesser restoration, spiritual weapon, dispel magic, spirit guardians</spells>
+		<spells>Light, Sacred Flame, Thaumaturgy, Cure Wounds, Guiding Bolt, Sanctuary, Lesser Restoration, Spiritual Weapon, Dispel Magic, Spirit Guardians</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -14712,7 +14712,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.</text>
 			<attack>Claw|5|1d6+3</attack>
 		</action>
-		<spells>feather fall, mage hand, cure wounds, enlarge/reduce, heat metal, mirror image</spells>
+		<spells>Feather Fall, Mage Hand, Cure Wounds, Enlarge/Reduce, Heat Metal, Mirror Image</spells>
 	</monster>
 	<monster>
 		<name>Quasit</name>
@@ -14837,7 +14837,7 @@
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage, and the target is cursed if it is a creature. The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a remove curse spell or similar magic.</text>
 			<attack>Claw|7|2d6+2</attack>
 		</action>
-		<spells>detect thoughts, disguise self, mage hand, minor illusion, charm person, detect magic, invisibility, major image, suggestion, dominate person, fly, plane shift, true seeing</spells>
+		<spells>Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion, Charm Person, Detect Magic, Invisibility, Major Image, Suggestion, Dominate Person, Fly, Plane Shift, True Seeing</spells>
 	</monster>
 	<monster>
 		<name>Rat</name>
@@ -15515,7 +15515,7 @@
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) slashing damage.</text>
 			<attack>Claws|3|1d4+1</attack>
 		</action>
-		<spells>guidance, thaumaturgy, bless, detect magic, guiding bolt, hold person, spiritual weapon, mass healing word, tongues</spells>
+		<spells>Guidance, Thaumaturgy, Bless, Detect Magic, Guiding Bolt, Hold Person, Spiritual Weapon, Mass Healing Word, Tongues</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -15774,7 +15774,7 @@
 			<text>The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies.</text>
 			<text>The changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have no claws, but someone touching her hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 16 Intelligence (Investigation) check to discern that the hag is disguised.</text>
 		</action>
-		<spells>identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Identify, Ray of Sickness, Hold Person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Sea Horse</name>
@@ -16141,7 +16141,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>dancing lights</spells>
+		<spells>Dancing Lights</spells>
 	</monster>
 	<monster>
 		<name>Solar</name>
@@ -16220,7 +16220,7 @@
 			<name>Blinding Gaze (Costs 3 Actions)</name>
 			<text>The solar targets one creature it can see within 30 ft. of it. If the target can see it, the target must succeed on a DC 15 Constitution saving throw or be blinded until magic such as the lesser restoration spell removes the blindness.</text>
 		</legendary>
-		<spells>detect evil and good, invisibility, blade barrier, dispel evil and good, resurrection, commune, control weather</spells>
+		<spells>Detect Evil and Good, Invisibility, Blade Barrier, Dispel Evil and Good, Resurrection, Commune, Control Weather</spells>
 	</monster>
 	<monster>
 		<name>Spectator</name>
@@ -16437,7 +16437,7 @@
 			<text>Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 7 (1d6 + 4) piercing damage, and the target must make a DC 13 Constitution saving throw, taking 31 (7d8) poison damage on a failed save, or half as much damage on a successful one.</text>
 			<attack>Bite|7|1d6+4</attack>
 		</action>
-		<spells>mage hand, minor illusion, ray of frost, charm person, detect magic, sleep, detect thoughts, hold person, lightning bolt, water breathing, blight, dimension door, dominate person</spells>
+		<spells>Mage Hand, Minor Illusion, Ray of Frost, Charm Person, Detect Magic, Sleep, Detect Thoughts, Hold Person, Lightning Bolt, Water Breathing, Blight, Dimension Door, Dominate Person</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -16565,7 +16565,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>blur</spells>
+		<spells>Blur</spells>
 	</monster>
 	<monster>
 		<name>Stirge</name>
@@ -16743,7 +16743,7 @@
 			<text>The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. Each creature within 10 feet of that point must make a DC 17 Dexterity saving throw, taking 54 (12d8) lightning damage on a failed save, or half as much damage on a successful one.</text>
 			<attack>Lightning Strike||12d8</attack>
 		</action>
-		<spells>detect magic, feather fall, levitate, light, control weather, water breathing</spells>
+		<spells>Detect Magic, Feather Fall, Levitate, Light, Control Weather, Water Breathing</spells>
 	</monster>
 	<monster>
 		<name>Succubus/Incubus</name>
@@ -17340,7 +17340,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) slashing damage.</text>
 			<attack>Chatkcha|4|1d6+2</attack>
 		</action>
-		<spells>mage hand, blur, magic weapon, invisibility</spells>
+		<spells>Mage Hand, Blur, Magic Weapon, Invisibility</spells>
 	</monster>
 	<monster>
 		<name>Thug</name>
@@ -17798,7 +17798,7 @@
 			<text>An ultroloth has a 50 percent chance of summoning 1d6 mezzoloths, 1d4 nycaloths, or one ultroloth.</text>
 			<text>A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other yugoloths. The summoned yugoloth remains for 1 minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it.</text>
 		</action>
-		<spells>alter self, clairvoyance, darkness, detect magic, detect thoughts, dispel magic, invisibility, suggestion, dimension door, fear, wall of fire, fire storm, mass suggestion</spells>
+		<spells>Alter Self, Clairvoyance, Darkness, Detect Magic, Detect Thoughts, Dispel Magic, Invisibility, Suggestion, Dimension Door, Fear, Wall of Fire, Fire Storm, Mass Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Umber Hulk</name>
@@ -17918,7 +17918,7 @@
 			<name>Heal Self (Costs 3 Actions)</name>
 			<text>The unicorn magically regains 11 (2d8 + 2) hit points.</text>
 		</legendary>
-		<spells>detect evil and good, druidcraft, pass without trace, calm emotions, dispel evil and good, entangle</spells>
+		<spells>Detect Evil and Good, Druidcraft, Pass without Trace, Calm Emotions, Dispel Evil and Good, Entangle</spells>
 	</monster>
 	<monster>
 		<name>Vampire</name>
@@ -18148,7 +18148,7 @@
 			<name>Children of the Night (1/Day)</name>
 			<text>The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action.</text>
 		</action>
-		<spells>mage hand, prestidigitation, ray of frost, comprehend languages, fog cloud, sleep, detect thoughts, gust of wind, mirror image, animate dead, bestow curse, nondetection, blight, greater invisibility, dominate person</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Comprehend Languages, Fog Cloud, Sleep, Detect Thoughts, Gust of Wind, Mirror Image, Animate Dead, Bestow Curse, Nondetection, Blight, Greater Invisibility, Dominate Person</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -19355,7 +19355,7 @@
 			<text>A yochlol has a 50 percent chance of summoning one yochlol.</text>
 			<text>A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>detect thoughts, web, dominate person</spells>
+		<spells>Detect Thoughts, Web, Dominate Person</spells>
 	</monster>
 	<monster>
 		<name>Young Black Dragon</name>
@@ -19954,7 +19954,7 @@
 			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 12 (2d8 + 3) piercing damage plus 10 (3d6) poison damage.</text>
 			<attack>Longbow|6|2d8+3+3d6</attack>
 		</action>
-		<spells>animal friendship, suggestion, fear</spells>
+		<spells>Animal Friendship, Suggestion, Fear</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Malison Type 1</name>
@@ -20020,7 +20020,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage plus 7 (2d6) poison damage.</text>
 			<attack>Longbow|4|1d8+2+2d6</attack>
 		</action>
-		<spells>animal friendship, suggestion</spells>
+		<spells>Animal Friendship, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Malison Type 2</name>
@@ -20076,7 +20076,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 5 (1d4 + 3) piercing damage plus 7 (2d6) poison damage.</text>
 			<attack>Bite|5|1d4+3+2d6</attack>
 		</action>
-		<spells>animal friendship, suggestion</spells>
+		<spells>Animal Friendship, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Malison Type 3</name>
@@ -20147,7 +20147,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
 			<attack>Longbow|4|1d8+2</attack>
 		</action>
-		<spells>animal friendship, suggestion</spells>
+		<spells>Animal Friendship, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Pureblood</name>
@@ -20195,7 +20195,7 @@
 			<text>Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 4 (1d6 + 1) piercing damage plus 7 (2d6) poison damage.</text>
 			<attack>Shortbow|3|1d6+1+2d6</attack>
 		</action>
-		<spells>animal friendship, poison spray, suggestion</spells>
+		<spells>Animal Friendship, Poison Spray, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Zombie</name>

--- a/Bestiary/Mordenkainen's Tome of Foes.xml
+++ b/Bestiary/Mordenkainen's Tome of Foes.xml
@@ -2449,7 +2449,7 @@
 			<name>Variant: Summon Demon (1/Day)</name>
 			<text>The drow attempts to magically summon a yochlol, with a 50 percent chance of success. If the attempt fails, the drow takes 5 (1d10) psychic damage. Otherwise, the summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate Self Only, Suggestion, Guidance, Message, Poison Spray, Resistance, Thaumaturgy, Bane, Cure Wounds, Inflict Wounds, Blindness/Deafness, Silence, Spiritual Weapon, Bestow Curse, Magic Circle, Banishment, Divination, Freedom of Movement, Contagion, Dispel Evil and Good, Insect Plague, Harm, True Seeing</spells>
+		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate, Suggestion, Guidance, Message, Poison Spray, Resistance, Thaumaturgy, Bane, Cure Wounds, Inflict Wounds, Blindness/Deafness, Silence, Spiritual Weapon, Bestow Curse, Magic Circle, Banishment, Divination, Freedom of Movement, Contagion, Dispel Evil and Good, Insect Plague, Harm, True Seeing</spells>
 		<slots>4,3,3,3,2,1</slots>
 	</monster>
 	<monster>
@@ -2552,7 +2552,7 @@
 			<name>Cast a Spell (Costs 1–3 Actions)</name>
 			<text>The drow expends a spell slot to cast a 1st-, 2nd-, or 3rd-level spell that she has prepared. Doing so costs 1 legendary action per level of the spell.</text>
 		</legendary>
-		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate Self Only, Suggestion, Guidance, Mending, Resistance, Sacred Flame, Thaumaturgy, Bane, Command, Cure Wounds, Guiding Bolt, Hold Person, Silence, Spiritual Weapon, Bestow Curse, Spirit Guardians, Banishment, Death Ward, Freedom of Movement, Guardian of Faith, Contagion, Flame Strike, Geas, Mass Cure Wounds, Blade Barrier, Harm, Divine Word, Plane Shift, Holy Aura, Gate</spells>
+		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate, Suggestion, Guidance, Mending, Resistance, Sacred Flame, Thaumaturgy, Bane, Command, Cure Wounds, Guiding Bolt, Hold Person, Silence, Spiritual Weapon, Bestow Curse, Spirit Guardians, Banishment, Death Ward, Freedom of Movement, Guardian of Faith, Contagion, Flame Strike, Geas, Mass Cure Wounds, Blade Barrier, Harm, Divine Word, Plane Shift, Holy Aura, Gate</spells>
 		<slots>4,3,3,3,3,2,2,1,1</slots>
 	</monster>
 	<monster>
@@ -4027,7 +4027,7 @@
 			<text>The githyanki adds 4 to its AC against one melee attack that would hit it. To do so, the githyanki must see the attacker and be wielding a melee weapon.</text>
 			<attack/>
 		</reaction>
-		<spells>Mage Hand, Blur, Jump, Misty Step, Nondetection, Plane Shift, Telekinesis.</spells>
+		<spells>Mage Hand, Blur, Jump, Misty Step, Nondetection, Plane Shift, Telekinesis</spells>
 		<slots/>
 	</monster>
 	<monster>
@@ -7524,7 +7524,7 @@
 			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) psychic damage.</text>
 			<attack>Longbow|7|1d8+3+1d8</attack>
 		</action>
-		<spells>Charm Person, Tasha's Hideous Laughter, Confusion, Enthrall, Suggestion, Hallucinatory Terrain, Otto's Irresistable Dance</spells>
+		<spells>Charm Person, Tasha's Hideous Laughter, Confusion, Enthrall, Suggestion, Hallucinatory Terrain, Otto's Irresistible Dance</spells>
 		<slots>0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Mordenkainen's Tome of Foes.xml
+++ b/Bestiary/Mordenkainen's Tome of Foes.xml
@@ -2449,7 +2449,7 @@
 			<name>Variant: Summon Demon (1/Day)</name>
 			<text>The drow attempts to magically summon a yochlol, with a 50 percent chance of success. If the attempt fails, the drow takes 5 (1d10) psychic damage. Otherwise, the summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 10 minutes, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate Self Only, Suggestion, Guidance, Message, Poison Spray, Resistance, Thaumaturgy, Bane, Cure Wounds, Inflict Wounds, Blindness/Deafness, Silence, Spiritual Weapon, Bestow Curse, Dispel Magic, Magic Circle, Banishment, Divination, Freedom of Movement, Contagion, Dispel Evil and Good, Insect Plague, Harm, True Seeing</spells>
+		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate Self Only, Suggestion, Guidance, Message, Poison Spray, Resistance, Thaumaturgy, Bane, Cure Wounds, Inflict Wounds, Blindness/Deafness, Silence, Spiritual Weapon, Bestow Curse, Magic Circle, Banishment, Divination, Freedom of Movement, Contagion, Dispel Evil and Good, Insect Plague, Harm, True Seeing</spells>
 		<slots>4,3,3,3,2,1</slots>
 	</monster>
 	<monster>
@@ -2552,7 +2552,7 @@
 			<name>Cast a Spell (Costs 1–3 Actions)</name>
 			<text>The drow expends a spell slot to cast a 1st-, 2nd-, or 3rd-level spell that she has prepared. Doing so costs 1 legendary action per level of the spell.</text>
 		</legendary>
-		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate Self Only, Suggestion, Guidance, Mending, Resistance, Sacred Flame, Thaumaturgy, Bane, Command, Cure Wounds, Guiding Bolt, Hold Person, Silence, Spiritual Weapon, Bestow Curse, Clairvoyance, Dispel Magic, Spirit Guardians, Banishment, Death Ward, Freedom of Movement, Guardian of Faith, Contagion, Flame Strike, Geas, Mass Cure Wounds, Blade Barrier, Harm, Divine Word, Plane Shift, Holy Aura, Gate</spells>
+		<spells>Dancing Lights, Detect Magic, Clairvoyance, Darkness, Detect Thoughts, Dispel Magic, Faerie Fire, Levitate Self Only, Suggestion, Guidance, Mending, Resistance, Sacred Flame, Thaumaturgy, Bane, Command, Cure Wounds, Guiding Bolt, Hold Person, Silence, Spiritual Weapon, Bestow Curse, Spirit Guardians, Banishment, Death Ward, Freedom of Movement, Guardian of Faith, Contagion, Flame Strike, Geas, Mass Cure Wounds, Blade Barrier, Harm, Divine Word, Plane Shift, Holy Aura, Gate</spells>
 		<slots>4,3,3,3,3,2,2,1,1</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Out of the Abyss.xml
+++ b/Bestiary/Out of the Abyss.xml
@@ -1030,7 +1030,7 @@
 			<text>Cantrips (at will): guidance, light, sacred flame, thaumaturgy</text>
 			<text>1st level (4 slots): cure wounds, divine favor, inflict wounds, protection from good, shield of faith</text>
 			<text>2nd level (3 slots): continual flame, hold person, magic weapon, spiritual weapon</text>
-			<text>3rd level (3 slots): bestow curse, dispel magic, spirit guardian</text>
+			<text>3rd level (3 slots): bestow curse, dispel magic, spirit guardians</text>
 		</trait>
 		<action>
 			<name>Multiattack</name>
@@ -1041,7 +1041,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage</text>
 			<attack>+1 Flail|5|1d8+3</attack>
 		</action>
-		<spells>Guidance, Light, Sacred Flame, Thaumaturgy, Cure Wounds, Divine Favor, Inflict Wounds, Protection from Evil and Good, Shield of Faith, Continual Flame, Hold Person, Magic Weapon, Spiritual Weapon, Bestow Curse, Dispel Magic, spirit guardian</spells>
+		<spells>Guidance, Light, Sacred Flame, Thaumaturgy, Cure Wounds, Divine Favor, Inflict Wounds, Protection from Evil and Good, Shield of Faith, Continual Flame, Hold Person, Magic Weapon, Spiritual Weapon, Bestow Curse, Dispel Magic, Spirit Guardians</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Out of the Abyss.xml
+++ b/Bestiary/Out of the Abyss.xml
@@ -93,7 +93,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 40/160 ft., one target. Hit: 6 (1d8+2) piercing damage.</text>
 			<attack>Light Repeating Crossbow|4|1d8+2</attack>
 		</action>
-		<spells>acid splash, light, mage hand, message, ray of frost, burning hands, chromatic orb, sleep, invisibility, spider climb, blink, lightning bolt</spells>
+		<spells>Acid Splash, Light, Mage Hand, Message, Ray of Frost, Burning Hands, Chromatic Orb, Sleep, Invisibility, Spider Climb, Blink, Lightning Bolt</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -165,7 +165,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
 			<attack>Barbed Tail|5|1d8+3</attack>
 		</reaction>
-		<spells>guidance, thaumaturgy, charm person, create or destroy water, hold person, silence, dispel magic, tongues</spells>
+		<spells>Guidance, Thaumaturgy, Charm Person, Create or Destroy Water, Hold Person, Silence, Dispel Magic, Tongues</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -237,7 +237,7 @@
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage.</text>
 			<attack>Barbed Tail|6|1d10+4</attack>
 		</reaction>
-		<spells>guidance, thaumaturgy, charm person, create or destroy water, hold person, silence, dispel magic, tongues</spells>
+		<spells>Guidance, Thaumaturgy, Charm Person, Create or Destroy Water, Hold Person, Silence, Dispel Magic, Tongues</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -295,7 +295,7 @@
 			<name>Invisibility (Recharges after a Short or Long Rest)</name>
 			<text>The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it.</text>
 		</action>
-		<spells>friends, mage hand, disguise self, sleep</spells>
+		<spells>Friends, Mage Hand, Disguise Self, Sleep</spells>
 	</monster>
 	<monster>
 		<name>Duergar Kavalrachni</name>
@@ -421,7 +421,7 @@
 			<name>Invisibility (Recharges after a Short or Long Rest)</name>
 			<text>The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it.</text>
 		</action>
-		<spells>friends, message, command, guidance, mending, sacred flame, bane, inflict wounds, shield of faith, enhance ability, spiritual weapon</spells>
+		<spells>Friends, Message, Command, Guidance, Mending, Sacred Flame, Bane, Inflict Wounds, Shield of Faith, Enhance Ability, Spiritual Weapon</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -477,7 +477,7 @@
 			<name>Invisibility (Recharges after a Short or Long Rest)</name>
 			<text>The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it.</text>
 		</action>
-		<spells>blade ward, true strike, jump, hunter's mark</spells>
+		<spells>Blade Ward, True Strike, Jump, Hunter's Mark</spells>
 	</monster>
 	<monster>
 		<name>Duergar Stone Guard</name>
@@ -1002,7 +1002,7 @@
 			<name>Parry</name>
 			<text>Droki adds 3 to his AC against one melee attack that would hit him. To do so, Droki must see the attacker and be wielding a melee weapon.</text>
 		</reaction>
-		<spells>minor illusion, darkness, fear, shatter</spells>
+		<spells>Minor Illusion, Darkness, Fear, Shatter</spells>
 	</monster>
 	<monster>
 		<name>Grisha</name>
@@ -1041,7 +1041,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage</text>
 			<attack>+1 Flail|5|1d8+3</attack>
 		</action>
-		<spells>guidance, light, sacred flame, thaumaturgy, cure wounds, divine favor, inflict wounds, protection from evil and good, shield of faith, continual flame, hold person, magic weapon, spiritual weapon, bestow curse, dispel magic, spirit guardian</spells>
+		<spells>Guidance, Light, Sacred Flame, Thaumaturgy, Cure Wounds, Divine Favor, Inflict Wounds, Protection from Evil and Good, Shield of Faith, Continual Flame, Hold Person, Magic Weapon, Spiritual Weapon, Bestow Curse, Dispel Magic, spirit guardian</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1096,7 +1096,7 @@
 			<name>One with Shadows</name>
 			<text>While he is in a dim light or darkness, Narrak can become invisible. He remains so until he moves or takes an action or reaction.</text>
 		</reaction>
-		<spells>eldritch blast, friends, poison spray, armor of agathys, charm person, hex, hold person, ray of enfeeblement, spider climb</spells>
+		<spells>Eldritch Blast, Friends, Poison Spray, Armor of Agathys, Charm Person, Hex, Hold Person, Ray of Enfeeblement, Spider Climb</spells>
 		<slots>0,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1164,7 +1164,7 @@
 			<name>Create Green Slime (Recharges after a Long Rest)</name>
 			<text>The Pudding King creates a patch of green slime (see "Dungeon Hazards" in chapter 5 of the Dungeon Master's Guide). The slime appears on a section of wall, ceiling, or floor within 30 feet of the Pudding King.</text>
 		</action>
-		<spells>acid splash, light, mage hand, poison spray, prestidigitation, false life, mage armor, ray of sickness, shield, crown of madness, misty step, gaseous form, stinking cloud, blight, confusion, cloudkill</spells>
+		<spells>Acid Splash, Light, Mage Hand, Poison Spray, Prestidigitation, False Life, Mage Armor, Ray of Sickness, Shield, Crown of Madness, Misty Step, Gaseous Form, Stinking Cloud, Blight, Confusion, Cloudkill</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1315,7 +1315,7 @@
 			<text>Baphomet moves up to his speed, then makes a gore attack.</text>
 			<attack>Charge|17|2d10+10</attack>
 		</legendary>
-		<spells>detect magic, dispel magic, dominate beast, hunter's mark, maze, wall of stone, teleport</spells>
+		<spells>Detect Magic, Dispel Magic, Dominate Beast, Hunter's Mark, Maze, Wall of Stone, Teleport</spells>
 	</monster>
 	<monster>
 		<name>Demogorgon</name>
@@ -1395,7 +1395,7 @@
 			<name>Maddening Gaze</name>
 			<text>Demogorgon uses his Gaze action, and must choose either the Beguiling Gaze or the Insanity Gaze effect.</text>
 		</legendary>
-		<spells>detect magic, major image, dispel magic, fear, telekinesis, feeblemind, project image</spells>
+		<spells>Detect Magic, Major Image, Dispel Magic, Fear, Telekinesis, Feeblemind, Project Image</spells>
 	</monster>
 	<monster>
 		<name>Fraz-Urb'luu</name>
@@ -1472,7 +1472,7 @@
 			<name>Phantasmal Killer (Costs 2 Actions)</name>
 			<text>Fraz-Urb'luu casts phantasmal killer, no concentration required.</text>
 		</legendary>
-		<spells>alter self, detect magic, dispel magic, phantasmal force, confusion, dream, mislead, programmed illusion, seeming, mirage arcane, modify memory, project image</spells>
+		<spells>Alter Self, Detect Magic, Dispel Magic, Phantasmal Force, Confusion, Dream, Mislead, Programmed Illusion, Seeming, Mirage Arcane, Modify Memory, Project Image</spells>
 	</monster>
 	<monster>
 		<name>Graz'zt</name>
@@ -1555,7 +1555,7 @@
 			<name>Teleport</name>
 			<text>Graz'zt uses his Teleport action.</text>
 		</legendary>
-		<spells>charm person, crown of madness, detect magic, dispel magic, dissonant whispers, counterspell, darkness, dominate person, sanctuary, telekinesis, teleport, dominate monster, greater invisibility</spells>
+		<spells>Charm Person, Crown of Madness, Detect Magic, Dispel Magic, Dissonant Whispers, Counterspell, Darkness, Dominate Person, Sanctuary, Telekinesis, Teleport, Dominate Monster, Greater Invisibility</spells>
 	</monster>
 	<monster>
 		<name>Juiblex</name>
@@ -1643,7 +1643,7 @@
 			<text>Melee Weapon Attack: +14 to hit, reach 10 ft., one creature. Hit: 21 (4d6+ 7) poison damage, and the target is slimed. Until the slime is scraped off with an action, the target is poisoned, and any creature, other than an ooze, is poisoned while Within 10 of the target.</text>
 			<attack>Corrupting Touch|14|4d6+7</attack>
 		</legendary>
-		<spells>acid splash, detect magic, blight, contagion, gaseous form</spells>
+		<spells>Acid Splash, Detect Magic, Blight, Contagion, Gaseous Form</spells>
 	</monster>
 	<monster>
 		<name>Orcus</name>
@@ -1728,7 +1728,7 @@
 			<name>Creeping Death (Costs 2 Actions)</name>
 			<text>Orcus chooses a point on the ground that he can see within 100 feet of him. A cylinder of swirling necrotic energy 60 feet tall and with a 10-foot radius rises from that point and lasts until the end of Orcus's next turn. Creatures in that area are vulnerable to necrotic damage.</text>
 		</legendary>
-		<spells>chill touch, detect magic, create undead, dispel magic, time stop</spells>
+		<spells>Chill Touch, Detect Magic, Create Undead, Dispel Magic, Time Stop</spells>
 	</monster>
 	<monster>
 		<name>Yeenoghu</name>
@@ -1811,7 +1811,7 @@
 			<name>Savage (Costs 2 Actions)</name>
 			<text>Yeenoghu makes a bite attack against each creature within 10 feet of him.</text>
 		</legendary>
-		<spells>detect magic, spiritual weapon, dispel magic, fear, invisibility, teleport</spells>
+		<spells>Detect Magic, Spiritual Weapon, Dispel Magic, Fear, Invisibility, Teleport</spells>
 	</monster>
 	<monster>
 		<name>Zuggtmoy</name>
@@ -1886,7 +1886,7 @@
 			<name>Exert Will</name>
 			<text>One creature charmed by Zuggtmoy that she can see must use its reaction to move up to its speed as she directs or to make a weapon attack against a target that she designates.</text>
 		</legendary>
-		<spells>detect magic, locate animals or plants, ray of sickness, dispel magic, ensnaring strike, entangle, plant growth, etherealness, teleport</spells>
+		<spells>Detect Magic, Locate Animals or Plants, Ray of Sickness, Dispel Magic, Ensnaring Strike, Entangle, Plant Growth, Etherealness, Teleport</spells>
 	</monster>
 	<monster>
 		<name>Giant Rocktopus</name>

--- a/Bestiary/Player's Handbook.xml
+++ b/Bestiary/Player's Handbook.xml
@@ -722,7 +722,7 @@
 			<text>The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).</text>
 			<text>In a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form.</text>
 		</action>
-		<spells>detect evil and good, detect magic, detect thoughts, bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield, dream, greater restoration, scrying</spells>
+		<spells>Detect Evil and Good, Detect Magic, Detect Thoughts, Bless, Create Food and Water, Cure Wounds, Lesser Restoration, Protection from Poison, Sanctuary, Shield, Dream, Greater Restoration, Scrying</spells>
 	</monster>
 	<monster>
 		<name>Crab</name>
@@ -910,7 +910,7 @@
 			<text>Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.</text>
 			<text>The dryad can have no more than one humanoid and up to three beasts charmed at a time.</text>
 		</action>
-		<spells>druidcraft, entangle, goodberry, barkskin, pass without trace, shillelagh</spells>
+		<spells>Druidcraft, Entangle, Goodberry, Barkskin, Pass without Trace, Shillelagh</spells>
 	</monster>
 	<monster>
 		<name>Dust Mephit</name>
@@ -957,7 +957,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>sleep</spells>
+		<spells>Sleep</spells>
 	</monster>
 	<monster>
 		<name>Eagle</name>
@@ -2516,7 +2516,7 @@
 			<name>Invisible Passage</name>
 			<text>The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her.</text>
 		</action>
-		<spells>dancing lights, minor illusion, vicious mockery, identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Dancing Lights, Minor Illusion, Vicious Mockery, Identify, Ray of Sickness, Hold Person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Hawk</name>
@@ -2657,7 +2657,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>fog cloud</spells>
+		<spells>Fog Cloud</spells>
 	</monster>
 	<monster>
 		<name>Imp</name>
@@ -2937,7 +2937,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>heat metal</spells>
+		<spells>Heat Metal</spells>
 	</monster>
 	<monster>
 		<name>Magmin</name>
@@ -3318,7 +3318,7 @@
 			<name>Superior Invisibility</name>
 			<text>The pixie magically turns invisible until its concentration ends (as if concentrating on a spell). Any equipment the pixie wears or carries is invisible with it.</text>
 		</action>
-		<spells>druidcraft, confusion, dancing lights, detect evil and good, detect thoughts, dispel magic, entangle, fly, phantasmal force, polymorph, sleep</spells>
+		<spells>Druidcraft, Confusion, Dancing Lights, Detect Evil and Good, Detect Thoughts, Dispel Magic, Entangle, Fly, Phantasmal Force, Polymorph, Sleep</spells>
 	</monster>
 	<monster>
 		<name>Plesiosaurus</name>
@@ -3943,7 +3943,7 @@
 			<text>The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies.</text>
 			<text>The changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have no claws, but someone touching her hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 16 Intelligence (Investigation) check to discern that the hag is disguised.</text>
 		</action>
-		<spells>identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Identify, Ray of Sickness, Hold Person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Sea Horse</name>
@@ -4043,7 +4043,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>dancing lights</spells>
+		<spells>Dancing Lights</spells>
 	</monster>
 	<monster>
 		<name>Spider</name>
@@ -4164,7 +4164,7 @@
 			<name>Variant: Summon Mephits (1/Day)</name>
 			<text>The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>blur</spells>
+		<spells>Blur</spells>
 	</monster>
 	<monster>
 		<name>Stirge</name>
@@ -4336,7 +4336,7 @@
 			<name>Heal Self (Costs 3 Actions)</name>
 			<text>The unicorn magically regains 11 (2d8 + 2) hit points.</text>
 		</legendary>
-		<spells>detect evil and good, druidcraft, pass without trace, calm emotions, dispel evil and good, entangle</spells>
+		<spells>Detect Evil and Good, Druidcraft, Pass without Trace, Calm Emotions, Dispel Evil and Good, Entangle</spells>
 	</monster>
 	<monster>
 		<name>Vulture</name>

--- a/Bestiary/Princes of the Apocalypse.xml
+++ b/Bestiary/Princes of the Apocalypse.xml
@@ -50,7 +50,7 @@
 			<attack>One Handed|9|1d6+6+1d6</attack>
 			<attack>Two Handed|9|1d8+6+1d6</attack>
 		</action>
-		<spells>gust (ee), mage hand, message, prestidigitation, ray of frost, shocking grasp, charm person, feather fall, mage armor, thunderwave, dust devil (ee), gust of wind, invisibility, fly, gaseous form, lightning bolt, ice storm, storm sphere (ee), cloudkill, seeming, chain lightning</spells>
+		<spells>gust (ee), Mage Hand, Message, Prestidigitation, Ray of Frost, Shocking Grasp, Charm Person, Feather Fall, Mage Armor, Thunderwave, dust devil (ee), Gust of Wind, Invisibility, Fly, Gaseous Form, Lightning Bolt, Ice Storm, storm sphere (ee), Cloudkill, Seeming, Chain Lightning</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -137,7 +137,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|5|1d4+2</attack>
 		</action>
-		<spells>produce flame, burning hands, fire bolt, mage hand, message, prestidigitation, shocking grasp, mage armor, magic missile, shield, misty step, scorching ray, counterspell, fireball, dimension door, wall of fire, hold monster</spells>
+		<spells>Produce Flame, Burning Hands, Fire Bolt, Mage Hand, Message, Prestidigitation, Shocking Grasp, Mage Armor, Magic Missile, Shield, Misty Step, Scorching Ray, Counterspell, Fireball, Dimension Door, Wall of Fire, Hold Monster</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -213,7 +213,7 @@
 			<name>Unyielding</name>
 			<text>When the priest is subjected to an effect that would move it, knock it prone, or both, it can use its reaction to be neither moved nor knocked prone.</text>
 		</reaction>
-		<spells>acid splash, blade ward, light, mending, mold earth (ee), earth tremor (ee), expeditious retreat, shield, shatter, spider climb, slow</spells>
+		<spells>Acid Splash, Blade Ward, Light, Mending, mold earth (ee), earth tremor (ee), Expeditious Retreat, Shield, Shatter, Spider Climb, Slow</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -287,7 +287,7 @@
 			<attack>One Handed|4|1d6+2</attack>
 			<attack>Two Handed|4|1d8+2</attack>
 		</action>
-		<spells>chill touch, mage hand, minor illusion, prestidigitation, ray of frost, expeditious retreat, ice knife (ee), magic missile, shield, blur, hold person, sleet storm</spells>
+		<spells>Chill Touch, Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Expeditious Retreat, ice knife (ee), Magic Missile, Shield, Blur, Hold Person, Sleet Storm</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -502,7 +502,7 @@
 			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
 			<attack>Dagger +1|6|1d4+3</attack>
 		</action>
-		<spells>druidcraft, guidance, poison spray, produce flame, animal friendship, faerie fire, healing word, jump, thunderwave, flame blade, spike growth, dispel magic, stinking cloud, blight, wall of fire</spells>
+		<spells>Druidcraft, Guidance, Poison Spray, Produce Flame, Animal Friendship, Faerie Fire, Healing Word, Jump, Thunderwave, Flame Blade, Spike Growth, Dispel Magic, Stinking Cloud, Blight, Wall of Fire</spells>
 		<slots>4,3,3,2,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -579,7 +579,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>control flames (ee), create bonfire (ee), fire bolt, light, minor illusion, burning hands, expeditious retreat, mage armor, blur, scorching ray, fireball</spells>
+		<spells>control flames (ee), create bonfire (ee), Fire Bolt, Light, Minor Illusion, Burning Hands, Expeditious Retreat, Mage Armor, Blur, Scorching Ray, Fireball</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -628,7 +628,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>chill touch, eldritch blast, mage hand, armor of agathys, expeditious retreat, hex, invisibility, vampiric touch</spells>
+		<spells>Chill Touch, Eldritch Blast, Mage Hand, Armor of Agathys, Expeditious Retreat, Hex, Invisibility, Vampiric Touch</spells>
 	</monster>
 	<monster>
 		<name>Feathergale Knight</name>
@@ -671,7 +671,7 @@
 			<attack>One Handed|4|1d6+2</attack>
 			<attack>Two Handed|4|1d8+2</attack>
 		</action>
-		<spells>gust (ee), light, message, ray of frost, expeditious retreat, feather fall</spells>
+		<spells>gust (ee), Light, Message, Ray of Frost, Expeditious Retreat, Feather Fall</spells>
 		<slots>2,0,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -761,7 +761,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|5|1d4+2</attack>
 		</action>
-		<spells>control flames (ee), fire bolt, friends, light, minor illusion, burning hands, color spray, mage armor, scorching ray, suggestion, fireball, hypnotic pattern, fire shield</spells>
+		<spells>control flames (ee), Fire Bolt, Friends, Light, Minor Illusion, Burning Hands, Color Spray, Mage Armor, Scorching Ray, Suggestion, Fireball, Hypnotic Pattern, Fire Shield</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -825,7 +825,7 @@
 			<attack>One Handed|7|1d6+3+1d8</attack>
 			<attack>Two Handed|7|1d8+3+1d8</attack>
 		</action>
-		<spells>mending, resistance, shape water (ee), create or destroy water, cure wounds, fog cloud, thunderwave, darkvision, hold person, protection from poison, call lightning, sleet storm, tidal wave (ee), control water, ice storm, scrying</spells>
+		<spells>Mending, Resistance, shape water (ee), Create or Destroy Water, Cure Wounds, Fog Cloud, Thunderwave, Darkvision, Hold Person, Protection from Poison, Call Lightning, Sleet Storm, tidal wave (ee), Control Water, Ice Storm, Scrying</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1016,7 +1016,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
 			<attack>Dagger|5|1d4+3</attack>
 		</action>
-		<spells>blade ward, gust (ee), light, prestidigitation, shocking grasp, feather fall, shield, witch bolt, dust devil (ee), gust of wind, gaseous form</spells>
+		<spells>Blade Ward, gust (ee), Light, Prestidigitation, Shocking Grasp, Feather Fall, Shield, Witch Bolt, dust devil (ee), Gust of Wind, Gaseous Form</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1066,7 +1066,7 @@
 			<name>Deflect Missiles</name>
 			<text>When the hurricane is hit by a ranged weapon attack, it reduces the damage from the attack by 1d10 + 9. If the damage is reduced to 0, the hurricane can catch the missile if it is small enough to hold in one hand and the hurricane has at least one hand free.</text>
 		</reaction>
-		<spells>blade ward, gust (ee), light, prestidigitation, feather fall, jump, thunderwave, gust of wind</spells>
+		<spells>Blade Ward, gust (ee), Light, Prestidigitation, Feather Fall, Jump, Thunderwave, Gust of Wind</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1156,7 +1156,7 @@
 			<text>Imix causes one creature he can see within 30 feet of him to burst into flames. The target must make a DC 21 Constitution saving throw. On a failed save, the target takes 70 (20d6) fire damage and catches fire. A target on fire takes 10 (3d6) fire damage when it starts its turn, and remains on fire until it or another creature takes an action to douse the flames. On a successful save, the target takes half as much damage and doesn't catch fire.</text>
 			<attack>Combustion||20d6</attack>
 		</legendary>
-		<spells>fireball, wall of fire, fire storm, haste, teleport</spells>
+		<spells>Fireball, Wall of Fire, Fire Storm, Haste, Teleport</spells>
 	</monster>
 	<monster>
 		<name>Marlos Urnrayle</name>
@@ -1257,7 +1257,7 @@
 			<attack>One Handed|4|1d6+1</attack>
 			<attack>Two Handed|4|1d8+1</attack>
 		</action>
-		<spells>pass without trace, acid splash, blade ward, friends, light, message, mold earth (ee), chromatic orb, mage armor, magic missile, Maximilian's earthen grasp (ee), shatter, suggestion, counterspell, erupting earth (ee), polymorph, stoneskin, wall of stone, move earth</spells>
+		<spells>Pass without Trace, Acid Splash, Blade Ward, Friends, Light, Message, mold earth (ee), Chromatic Orb, Mage Armor, Magic Missile, Maximilian's earthen grasp (ee), Shatter, Suggestion, Counterspell, erupting earth (ee), Polymorph, Stoneskin, Wall of Stone, Move Earth</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1335,7 +1335,7 @@
 			<name>Create Gargoyle (Costs 3 Actions)</name>
 			<text>Ogremoch's hit points are reduced by 50 as he breaks off a chunk of his body and places it on the ground in an unoccupied space within 15 feet of him. The chunk of rock instantly transforms into a gargoyle and acts on the same initiative count as Ogremoch. Ogremoch can't use this action if he has 50 hit points or fewer. The gargoyle obeys Ogremoch's commands and fights until destroyed.</text>
 		</legendary>
-		<spells>meld into stone, move earth, wall of stone</spells>
+		<spells>Meld into Stone, Move Earth, Wall of Stone</spells>
 	</monster>
 	<monster>
 		<name>Olhydra</name>
@@ -1417,7 +1417,7 @@
 			<attack>Contact||2d10</attack>
 			<attack>Grappled||4d10</attack>
 		</legendary>
-		<spells>wall of ice, ice storm, storm of vengeance</spells>
+		<spells>Wall of Ice, Ice Storm, Storm of Vengeance</spells>
 	</monster>
 	<monster>
 		<name>One-Eyed Shiver</name>
@@ -1461,7 +1461,7 @@
 			<name>Eye of Frost</name>
 			<text>The one-eyed shiver casts ray of frost from its missing eye. If it hits, the target is also restrained. A target restrained in this way can end the condition by using an action, succeeding on a DC 13 Strength check.</text>
 		</action>
-		<spells>chill touch, mage hand, fog cloud, mage armor, thunderwave, mirror image, misty step, fear</spells>
+		<spells>Chill Touch, Mage Hand, Fog Cloud, Mage Armor, Thunderwave, Mirror Image, Misty Step, Fear</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1505,7 +1505,7 @@
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage.</text>
 			<attack>Dagger|3|1d4+1</attack>
 		</action>
-		<spells>chill touch, minor illusion, prestidigitation, shocking grasp, false life, mage armor, magic missile, ray of sickness, crown of madness, misty step, animate dead, vampiric touch</spells>
+		<spells>Chill Touch, Minor Illusion, Prestidigitation, Shocking Grasp, False Life, Mage Armor, Magic Missile, Ray of Sickness, Crown of Madness, Misty Step, Animate Dead, Vampiric Touch</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1634,7 +1634,7 @@
 			<text>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or ranged 20/60 ft., one target. Hit: 3 (1d4 + 1) piercing damage.</text>
 			<attack>Dagger|3|1d4+1</attack>
 		</action>
-		<spells>shape water (ee), create or destroy water, acid splash, chill touch, friends, prestidigitation, ray of frost, disguise self, mage armor, magic missile, hold person, misty step, tidal wave (ee)</spells>
+		<spells>shape water (ee), Create or Destroy Water, Acid Splash, Chill Touch, Friends, Prestidigitation, Ray of Frost, Disguise Self, Mage Armor, Magic Missile, Hold Person, Misty Step, tidal wave (ee)</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1669,7 +1669,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 3 (1d4 + 1) piercing damage.</text>
 			<attack>Dagger|4|1d4+1</attack>
 		</action>
-		<spells>blade ward, light, message, ray of frost, shocking grasp, feather fall, mage armor, witch bolt, gust of wind, invisibility, fly, lightning bolt</spells>
+		<spells>Blade Ward, Light, Message, Ray of Frost, Shocking Grasp, Feather Fall, Mage Armor, Witch Bolt, Gust of Wind, Invisibility, Fly, Lightning Bolt</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1711,7 +1711,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage. The Stonemelder can also expend a spell slot to deal extra damage, dealing 2d8 bludgeoning damage for a 1st level slot, plus an additional 1d8 for each level of the slot above 1st.</text>
 			<attack>Black Earth Rod|5|1d6+2</attack>
 		</action>
-		<spells>acid splash, blade ward, light, mending, mold earth (ee), expeditious retreat, false life, shield, Maximilian's earthen grasp (ee), shatter, erupting earth (ee), meld into stone, stoneskin</spells>
+		<spells>Acid Splash, Blade Ward, Light, Mending, mold earth (ee), Expeditious Retreat, False Life, Shield, Maximilian's earthen grasp (ee), Shatter, erupting earth (ee), Meld into Stone, Stoneskin</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1759,7 +1759,7 @@
 			<name>Parry</name>
 			<text>Thurl adds 2 to his AC against one melee attack that would hit him. To do so, Thurl must see the attacker and be wielding a melee weapon.</text>
 		</reaction>
-		<spells>friends, gust (ee), light, message, ray of frost, expeditious retreat, feather fall, jump, levitate, misty step, haste</spells>
+		<spells>Friends, gust (ee), Light, Message, Ray of Frost, Expeditious Retreat, Feather Fall, Jump, Levitate, Misty Step, Haste</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1810,7 +1810,7 @@
 			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage plus 7 (2d6) fire damage.</text>
 			<attack>Tinderstrike|9|1d4+5+2d6</attack>
 		</action>
-		<spells>chill touch, fire bolt, friends, mage hand, message, produce flame, thaumaturgy, burning hands, chromatic orb, hellish rebuke, shield, darkness, detect thoughts, misty step, scorching ray, counterspell, fireball, hypnotic pattern, wall of fire, dominate person</spells>
+		<spells>Chill Touch, Fire Bolt, Friends, Mage Hand, Message, Produce Flame, Thaumaturgy, Burning Hands, Chromatic Orb, Hellish Rebuke, Shield, Darkness, Detect Thoughts, Misty Step, Scorching Ray, Counterspell, Fireball, Hypnotic Pattern, Wall of Fire, Dominate Person</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1894,7 +1894,7 @@
 			<attack>Wooden Cane|0|1d4-1</attack>
 			<attack>Shillelagh|4|1d8+2</attack>
 		</action>
-		<spells>guidance, light, mending, shillelagh, thaumaturgy, animal friendship, cure wounds, healing word, inflict wounds, speak with animals, barkskin, spike growth, spiritual weapon</spells>
+		<spells>Guidance, Light, Mending, Shillelagh, Thaumaturgy, Animal Friendship, Cure Wounds, Healing Word, Inflict Wounds, Speak with Animals, Barkskin, Spike Growth, Spiritual Weapon</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1939,7 +1939,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 7 (1d8 + 3) piercing damage.</text>
 			<attack>Rapier|5|1d8+3</attack>
 		</action>
-		<spells>friends, prestidigitation, vicious mockery, disguise self, dissonant whispers, thunderwave, invisibility, shatter, silence, nondetection, sending, tongues, confusion, dimension door</spells>
+		<spells>Friends, Prestidigitation, Vicious Mockery, Disguise Self, Dissonant Whispers, Thunderwave, Invisibility, Shatter, Silence, Nondetection, Sending, Tongues, Confusion, Dimension Door</spells>
 		<slots>4,3,3,2,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -2023,6 +2023,6 @@
 			<name>Suffocate (Costs 3 Actions)</name>
 			<text>Yan-C-Bin steals the air of one breathing creature he can see within 60 feet of him. The target must make a DC 21 Constitution saving throw. On a failed save, the target drops to 0 hit points and is dying. On a successful save, the target can't breathe or speak until the start of its next turn.</text>
 		</legendary>
-		<spells>gust of wind, invisibility, lightning bolt, chain lightning, cloudkill, haste</spells>
+		<spells>Gust of Wind, Invisibility, Lightning Bolt, Chain Lightning, Cloudkill, Haste</spells>
 	</monster>
 </compendium>

--- a/Bestiary/Princes of the Apocalypse.xml
+++ b/Bestiary/Princes of the Apocalypse.xml
@@ -50,7 +50,7 @@
 			<attack>One Handed|9|1d6+6+1d6</attack>
 			<attack>Two Handed|9|1d8+6+1d6</attack>
 		</action>
-		<spells>gust (ee), Mage Hand, Message, Prestidigitation, Ray of Frost, Shocking Grasp, Charm Person, Feather Fall, Mage Armor, Thunderwave, dust devil (ee), Gust of Wind, Invisibility, Fly, Gaseous Form, Lightning Bolt, Ice Storm, storm sphere (ee), Cloudkill, Seeming, Chain Lightning</spells>
+		<spells>Gust, Mage Hand, Message, Prestidigitation, Ray of Frost, Shocking Grasp, Charm Person, Feather Fall, Mage Armor, Thunderwave, Dust Devil, Gust of Wind, Invisibility, Fly, Gaseous Form, Lightning Bolt, Ice Storm, Storm Sphere, Cloudkill, Seeming, Chain Lightning</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -213,7 +213,7 @@
 			<name>Unyielding</name>
 			<text>When the priest is subjected to an effect that would move it, knock it prone, or both, it can use its reaction to be neither moved nor knocked prone.</text>
 		</reaction>
-		<spells>Acid Splash, Blade Ward, Light, Mending, mold earth (ee), earth tremor (ee), Expeditious Retreat, Shield, Shatter, Spider Climb, Slow</spells>
+		<spells>Acid Splash, Blade Ward, Light, Mending, Mold Earth, Earth Tremor, Expeditious Retreat, Shield, Shatter, Spider Climb, Slow</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -287,7 +287,7 @@
 			<attack>One Handed|4|1d6+2</attack>
 			<attack>Two Handed|4|1d8+2</attack>
 		</action>
-		<spells>Chill Touch, Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Expeditious Retreat, ice knife (ee), Magic Missile, Shield, Blur, Hold Person, Sleet Storm</spells>
+		<spells>Chill Touch, Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Expeditious Retreat, Ice Knife, Magic Missile, Shield, Blur, Hold Person, Sleet Storm</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -579,7 +579,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>control flames (ee), create bonfire (ee), Fire Bolt, Light, Minor Illusion, Burning Hands, Expeditious Retreat, Mage Armor, Blur, Scorching Ray, Fireball</spells>
+		<spells>Control Flames, Create Bonfire, Fire Bolt, Light, Minor Illusion, Burning Hands, Expeditious Retreat, Mage Armor, Blur, Scorching Ray, Fireball</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -671,7 +671,7 @@
 			<attack>One Handed|4|1d6+2</attack>
 			<attack>Two Handed|4|1d8+2</attack>
 		</action>
-		<spells>gust (ee), Light, Message, Ray of Frost, Expeditious Retreat, Feather Fall</spells>
+		<spells>Gust, Light, Message, Ray of Frost, Expeditious Retreat, Feather Fall</spells>
 		<slots>2,0,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -761,7 +761,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|5|1d4+2</attack>
 		</action>
-		<spells>control flames (ee), Fire Bolt, Friends, Light, Minor Illusion, Burning Hands, Color Spray, Mage Armor, Scorching Ray, Suggestion, Fireball, Hypnotic Pattern, Fire Shield</spells>
+		<spells>Control Flames, Fire Bolt, Friends, Light, Minor Illusion, Burning Hands, Color Spray, Mage Armor, Scorching Ray, Suggestion, Fireball, Hypnotic Pattern, Fire Shield</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -825,7 +825,7 @@
 			<attack>One Handed|7|1d6+3+1d8</attack>
 			<attack>Two Handed|7|1d8+3+1d8</attack>
 		</action>
-		<spells>Mending, Resistance, shape water (ee), Create or Destroy Water, Cure Wounds, Fog Cloud, Thunderwave, Darkvision, Hold Person, Protection from Poison, Call Lightning, Sleet Storm, tidal wave (ee), Control Water, Ice Storm, Scrying</spells>
+		<spells>Mending, Resistance, Shape Water, Create or Destroy Water, Cure Wounds, Fog Cloud, Thunderwave, Darkvision, Hold Person, Protection from Poison, Call Lightning, Sleet Storm, Tidal Wave, Control Water, Ice Storm, Scrying</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -998,7 +998,7 @@
 			<name>Spellcasting</name>
 			<text>The priest is a 5th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 12, +4 to hit with spell attacks). It knows the following sorcerer spells:</text>
 			<text>Cantrips (at will): blade ward, gust, light, prestidigitation, shocking grasp</text>
-			<text>1st level (4 slots): featherfall, shield, witch bolt</text>
+			<text>1st level (4 slots): feather fall, shield, witch bolt</text>
 			<text>2nd level (3 slots): dust devil, gust of wind</text>
 			<text>3rd level (2 slots): gaseous form</text>
 		</trait>
@@ -1016,7 +1016,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
 			<attack>Dagger|5|1d4+3</attack>
 		</action>
-		<spells>Blade Ward, gust (ee), Light, Prestidigitation, Shocking Grasp, Feather Fall, Shield, Witch Bolt, dust devil (ee), Gust of Wind, Gaseous Form</spells>
+		<spells>Blade Ward, Gust, Light, Prestidigitation, Shocking Grasp, Feather Fall, Shield, Witch Bolt, Dust Devil, Gust of Wind, Gaseous Form</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1066,7 +1066,7 @@
 			<name>Deflect Missiles</name>
 			<text>When the hurricane is hit by a ranged weapon attack, it reduces the damage from the attack by 1d10 + 9. If the damage is reduced to 0, the hurricane can catch the missile if it is small enough to hold in one hand and the hurricane has at least one hand free.</text>
 		</reaction>
-		<spells>Blade Ward, gust (ee), Light, Prestidigitation, Feather Fall, Jump, Thunderwave, Gust of Wind</spells>
+		<spells>Blade Ward, Gust, Light, Prestidigitation, Feather Fall, Jump, Thunderwave, Gust of Wind</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1257,7 +1257,7 @@
 			<attack>One Handed|4|1d6+1</attack>
 			<attack>Two Handed|4|1d8+1</attack>
 		</action>
-		<spells>Pass without Trace, Acid Splash, Blade Ward, Friends, Light, Message, mold earth (ee), Chromatic Orb, Mage Armor, Magic Missile, Maximilian's earthen grasp (ee), Shatter, Suggestion, Counterspell, erupting earth (ee), Polymorph, Stoneskin, Wall of Stone, Move Earth</spells>
+		<spells>Pass without Trace, Acid Splash, Blade Ward, Friends, Light, Message, Mold Earth, Chromatic Orb, Mage Armor, Magic Missile, Maximilian's Earthen Grasp, Shatter, Suggestion, Counterspell, Erupting Earth, Polymorph, Stoneskin, Wall of Stone, Move Earth</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1634,7 +1634,7 @@
 			<text>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or ranged 20/60 ft., one target. Hit: 3 (1d4 + 1) piercing damage.</text>
 			<attack>Dagger|3|1d4+1</attack>
 		</action>
-		<spells>shape water (ee), Create or Destroy Water, Acid Splash, Chill Touch, Friends, Prestidigitation, Ray of Frost, Disguise Self, Mage Armor, Magic Missile, Hold Person, Misty Step, tidal wave (ee)</spells>
+		<spells>Shape Water, Create or Destroy Water, Acid Splash, Chill Touch, Friends, Prestidigitation, Ray of Frost, Disguise Self, Mage Armor, Magic Missile, Hold Person, Misty Step, Tidal Wave</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1711,7 +1711,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage. The Stonemelder can also expend a spell slot to deal extra damage, dealing 2d8 bludgeoning damage for a 1st level slot, plus an additional 1d8 for each level of the slot above 1st.</text>
 			<attack>Black Earth Rod|5|1d6+2</attack>
 		</action>
-		<spells>Acid Splash, Blade Ward, Light, Mending, mold earth (ee), Expeditious Retreat, False Life, Shield, Maximilian's earthen grasp (ee), Shatter, erupting earth (ee), Meld into Stone, Stoneskin</spells>
+		<spells>Acid Splash, Blade Ward, Light, Mending, Mold Earth, Expeditious Retreat, False Life, Shield, Maximilian's Earthen Grasp, Shatter, Erupting Earth, Meld into Stone, Stoneskin</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1759,7 +1759,7 @@
 			<name>Parry</name>
 			<text>Thurl adds 2 to his AC against one melee attack that would hit him. To do so, Thurl must see the attacker and be wielding a melee weapon.</text>
 		</reaction>
-		<spells>Friends, gust (ee), Light, Message, Ray of Frost, Expeditious Retreat, Feather Fall, Jump, Levitate, Misty Step, Haste</spells>
+		<spells>Friends, Gust, Light, Message, Ray of Frost, Expeditious Retreat, Feather Fall, Jump, Levitate, Misty Step, Haste</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Storm King's Thunder.xml
+++ b/Bestiary/Storm King's Thunder.xml
@@ -154,7 +154,7 @@
 			<name>Wing Attack (Costs 2 Actions)</name>
 			<text>The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.</text>
 		</legendary>
-		<spells>counterspell, detect magic, ice storm, stone shape, teleport</spells>
+		<spells>Counterspell, Detect Magic, Ice Storm, Stone Shape, Teleport</spells>
 	</monster>
 	<monster>
 		<name>Maegera the Dawn Titan</name>
@@ -336,7 +336,7 @@
 			<text>Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 4 (1d6 + 1) piercing damage.</text>
 			<attack>Shortbow|3|1d6+1</attack>
 		</action>
-		<spells> dancing lights, message, mage hand, thaumaturgy, augury, bestow curse, cordon of arrows, detect magic, hex, prayer of healing, speak with dead, spirit guardians</spells>
+		<spells> dancing lights, Message, Mage Hand, Thaumaturgy, Augury, Bestow Curse, Cordon of Arrows, Detect Magic, Hex, Prayer of Healing, Speak with Dead, Spirit Guardians</spells>
 	</monster>
 	<monster>
 		<name>Yakfolk Warrior</name>
@@ -423,7 +423,7 @@
 			<name>Summon Earth Elemental (1/day)</name>
 			<text>The yakfolk summons an earth elemental. The elemental appears in an unoccupied space within 60 feet of its summoner and acts as an ally of the summoner. It remains for 10 minutes, until it dies, or until its summoner dismisses it as an action.</text>
 		</action>
-		<spells>light, mending, sacred flame, thaumaturgy, bane, command, cure wounds, sanctuary, augury, hold person, spiritual weapon, bestow curse, protection from energy, sending, banishment</spells>
+		<spells>Light, Mending, Sacred Flame, Thaumaturgy, Bane, Command, Cure Wounds, Sanctuary, Augury, Hold Person, Spiritual Weapon, Bestow Curse, Protection from Energy, Sending, Banishment</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<!--Special NPCs-->
@@ -890,7 +890,7 @@
 			<text>Bond: "I have great respect for Lady Laeral Silverhand of Waterdeep. She and the Lords' Alliance are going to bring some much-needed order to this lawless land."</text>
 			<text>Flaw: "I'm too smart to be wrong about anything."</text>
 		</trait>
-		<spells>fire bolt, light, mage hand, prestidigitation, mage armor, magic missile, shield, misty step, suggestion, fly, lightning bolt</spells>
+		<spells>Fire Bolt, Light, Mage Hand, Prestidigitation, Mage Armor, Magic Missile, Shield, Misty Step, Suggestion, Fly, Lightning Bolt</spells>
 		<slots>4,3,3,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>

--- a/Bestiary/Storm King's Thunder.xml
+++ b/Bestiary/Storm King's Thunder.xml
@@ -336,7 +336,7 @@
 			<text>Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 4 (1d6 + 1) piercing damage.</text>
 			<attack>Shortbow|3|1d6+1</attack>
 		</action>
-		<spells> dancing lights, Message, Mage Hand, Thaumaturgy, Augury, Bestow Curse, Cordon of Arrows, Detect Magic, Hex, Prayer of Healing, Speak with Dead, Spirit Guardians</spells>
+		<spells>Dancing Lights, Message, Mage Hand, Thaumaturgy, Augury, Bestow Curse, Cordon of Arrows, Detect Magic, Hex, Prayer of Healing, Speak with Dead, Spirit Guardians</spells>
 	</monster>
 	<monster>
 		<name>Yakfolk Warrior</name>

--- a/Bestiary/Tales From the Yawining Portal.xml
+++ b/Bestiary/Tales From the Yawining Portal.xml
@@ -169,7 +169,7 @@
 			<text>	A humanoid slain by this attack rises 24 hours later as a zombie under the wight's control, unless the humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at one time.</text>
 			<attack>Life Drain|4|2d6+2</attack>
 		</action>
-		<spells>detect magic, disguise self, mage armor, fear, hold person, misty step</spells>
+		<spells>Detect Magic, Disguise Self, Mage Armor, Fear, Hold Person, Misty Step</spells>
 		<slots/>
 	</monster>
 	<monster>
@@ -805,7 +805,7 @@
 			<text>If a creature the Ooze Master can see makes an attack roll against it while within 30 feet of it, the Ooze Master can use a reaction to divert the attack if another creature is within the attack's range. The attacker must make a DC 15 Wisdom saving throw. On a failed save, the attacker targets the creature that is closest to it, not including itself or the Ooze Master. If multiple creatures are closest, the attacker chooses which one to target. On a successful save, the attacker is immune to this Instinctive Charm for 24 hours. Creatures that can't be charmed are immune to this effect.</text>
 			<attack/>
 		</reaction>
-		<spells>acid splash, friends, mage hand, poison spray, charm person, detect magic, magic missile, ray of sickness, detect thoughts, Melf's acid arrow, suggestion, fear, slow, stinking cloud, confusion, Evard's black tentacles, cloudkill</spells>
+		<spells>Acid Splash, Friends, Mage Hand, Poison Spray, Charm Person, Detect Magic, Magic Missile, Ray of Sickness, Detect Thoughts, Melf's Acid Arrow, Suggestion, Fear, Slow, Stinking Cloud, Confusion, Evard's Black Tentacles, Cloudkill</spells>
 		<slots>4,3,3,3,1</slots>
 	</monster>
 	<monster>
@@ -922,7 +922,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>light, prestidigitation, ray of frost, color spray, magic missile, shield, sleep</spells>
+		<spells>Light, Prestidigitation, Ray of Frost, Color Spray, Magic Missile, Shield, Sleep</spells>
 		<slots>2</slots>
 	</monster>
 	<monster>
@@ -1031,7 +1031,7 @@
 			<name>Stupefying Touch</name>
 			<text>Siren touches one creature she can see within 5 feet of her. The creature must succeed on a DC 13 Intelligence saving throw or take 13 (3d6 + 3) psychic damage and be stunned until the start of Siren's next turn.</text>
 		</action>
-		<spells>charm person, fog cloud, greater invisibility, polymorph</spells>
+		<spells>Charm Person, Fog Cloud, Greater Invisibility, Polymorph</spells>
 		<slots/>
 	</monster>
 	<monster>
@@ -1120,7 +1120,7 @@
 			<name>Frightening Gaze (Costs 2 Actions)</name>
 			<text>Var fixes his gaze on one creature he can see within 10 feet of him. The target must succeed on a DC 17 Wisdom saving throw against this magic or become frightened for 1 minute. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to Var's gaze for the next 24 hours.</text>
 		</legendary>
-		<spells>fire bolt, mage hand, minor illusion, prestidigitation, ray of frost, detect magic, magic missile, shield, unseen servant, detect thoughts, flaming sphere, mirror image, scorching ray, counterspell, dispel magic, fireball, dimension door, Evard's black tentacles, cloudkill, scrying, circle of death</spells>
+		<spells>Fire Bolt, Mage Hand, Minor Illusion, Prestidigitation, Ray of Frost, Detect Magic, Magic Missile, Shield, Unseen Servant, Detect Thoughts, Flaming Sphere, Mirror Image, Scorching Ray, Counterspell, Dispel Magic, Fireball, Dimension Door, Evard's Black Tentacles, Cloudkill, Scrying, Circle of Death</spells>
 		<slots>4,3,3,3,3,1</slots>
 	</monster>
 	<monster>
@@ -1388,7 +1388,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>mage hand, prestidigitation, ray of frost, shocking grasp, burning hands, chromatic orb, mage armor</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Shocking Grasp, Burning Hands, Chromatic Orb, Mage Armor</spells>
 		<slots>4</slots>
 	</monster>
 </compendium>

--- a/Bestiary/Tomb of Annihilation.xml
+++ b/Bestiary/Tomb of Annihilation.xml
@@ -243,7 +243,7 @@ Perception +4, Stealth +3, Survival +4
 			<text>• Cast dimension door from the dagger. Once this property is used, it can't be used again until the next dawn.</text>
 			<text>• Cast compulsion (save DC 15) from the dagger. The range of the spell increases to 90 feet, but the spell targets only spiders that are beasts. Once this property is used, it can't be used again until the next dawn.</text>
 		</trait>
-		<spells>Compulsion, Bigby's Hand, Cone of Cold, Flesh to Ice, Ice Storm, Otiluke's Freezing Sphere, Sleet Storm, Spike Growth, Wall of Ice</spells>
+		<spells>Compulsion, Bigby's Hand, Cone of Cold, Flesh to Stone, Ice Storm, Otiluke's Freezing Sphere, Sleet Storm, Spike Growth, Wall of Ice</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Artus makes three attacks with Bookmark or his longbow.</text>
@@ -2344,7 +2344,7 @@ Perception +4, Stealth +3, Survival +4
 			<name>Spellcasting</name>
 			<text>Xandala is a 9th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). Xandala has the following sorcerer spells prepared:</text>
 			<text>Cantrips (at will): acid splash, fire bolt, light, mage hand, ray of frost</text>
-			<text>1st level (4 slots): chromatic orb, featherfall, shield</text>
+			<text>1st level (4 slots): chromatic orb, feather fall, shield</text>
 			<text>2nd level (4 slots): invisibility, misty step</text>
 			<text>3rd level (3 slots): fireball, fly</text>
 			<text>4th level (3 slots): ice storm, polymorph</text>
@@ -2352,7 +2352,7 @@ Perception +4, Stealth +3, Survival +4
 		</trait>
 		<spellAbility>Charisma</spellAbility>
 		<slots>4,4,3,3,1,0,0,0,0</slots>
-		<spells>Acid Splash, Fire Bolt, Light, Mage Hand, Ray of Frost, Chromatic Orb, Featherfall, Shield, Invisibility, Misty Step, Fireball, Fly, Ice Storm, Polymorph, Dominate Person</spells>
+		<spells>Acid Splash, Fire Bolt, Light, Mage Hand, Ray of Frost, Chromatic Orb, Feather Fall, Shield, Invisibility, Misty Step, Fireball, Fly, Ice Storm, Polymorph, Dominate Person</spells>
 		<trait>
 			<name>Quickened Spell (3/Day)</name>
 			<text>When she casts a spell that has a casting time of 1 action, Xandala changes the casting time to 1 bonus action for that casting.</text>

--- a/Bestiary/Tortle Package.xml
+++ b/Bestiary/Tortle Package.xml
@@ -181,7 +181,7 @@
 			<text>1st Level (4 slots): animal friendship, cure wounds, speak with animals, thunderwave</text>
 			<text>2nd Level (3 slots): darkvision, hold person</text>
 		</trait>
-		<spells>druidcraft, guidance, produce flame, animal friendship, cure wounds, speak with animals, thunderwave, darkvision, hold person</spells>
+		<spells>Druidcraft, Guidance, Produce Flame, Animal Friendship, Cure Wounds, Speak with Animals, Thunderwave, Darkvision, Hold Person</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 		<action>
 			<name>Claws</name>

--- a/Bestiary/Volo's Guide to Monsters.xml
+++ b/Bestiary/Volo's Guide to Monsters.xml
@@ -716,7 +716,7 @@
 			<name>Maddening Feast</name>
 			<text>The hag feasts on the corpse of one enemy within 5 feet of her that died within the past minute. Each creature of the hag's choice that is within 60 feet of her and able to see her must succeed on a DC 15 Wisdom saving throw or be frightened of her for 1 minute. While frightened in this way, a creature is incapacitated, can't understand what others say, can't read, and speaks only in gibberish; the DM controls the creature's movement, which is erratic. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Maddening Feast for the next 24 hours.</text>
 		</action>
-		<spells>Hold Person, Ray of Frost, Cone of Cold, Ice Storm, Wall of Ice, Control Weather, Identify, Ray of Sickness, hold person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
+		<spells>Hold Person, Ray of Frost, Cone of Cold, Ice Storm, Wall of Ice, Control Weather, Identify, Ray of Sickness, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Black Guard Drake</name>

--- a/Bestiary/Volo's Guide to Monsters.xml
+++ b/Bestiary/Volo's Guide to Monsters.xml
@@ -48,7 +48,7 @@
 			<attack>Quarterstaff|3|1d6-l</attack>
 			<attack>Two Handed|3|1d8-1</attack>
 		</action>
-		<spells>blade ward. dancing lights, mending, message, ray of frost, alarm, mage armor, magic missile, shield, arcane lock, invisibility, counterspell, dispel magic, fireball, banishment, stoneskin, cone of cold, wall of force, flesh to stone, globe of invulnerability, symbol teleport</spells>
+		<spells>blade ward. dancing lights, Mending, Message, Ray of Frost, Alarm, Mage Armor, Magic Missile, Shield, Arcane Lock, Invisibility, Counterspell, Dispel Magic, Fireball, Banishment, Stoneskin, Cone of Cold, Wall of Force, Flesh to Stone, Globe of Invulnerability, symbol teleport</spells>
 		<slots>4,3,3,3,2,1,1,0,0</slots>
 	</monster>
 	<monster>
@@ -111,7 +111,7 @@
 			<text>The alhoon magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 16 Intelligence saving throw or take 22 (4d8+4) psychic damage and be stunned for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 			<attack>Mind Blast| |4d8+4</attack>
 		</action>
-		<spells>detect thoughts, levitate, dominate monster, plane shift, chill touch, dancing lights, mage hand, prestidigitation, shocking grasp, detect magic, disguise self, magic missile, shield, invisibility, mirror image, scorching ray, counterspell, fly, lightning bolt, confusion, Evard's black tentacles, phantasmal killer, modify memory, wall of force, disintegrate, globe of invulnerability</spells>
+		<spells>Detect Thoughts, Levitate, Dominate Monster, Plane Shift, Chill Touch, Dancing Lights, Mage Hand, Prestidigitation, Shocking Grasp, Detect Magic, Disguise Self, Magic Missile, Shield, Invisibility, Mirror Image, Scorching Ray, Counterspell, Fly, Lightning Bolt, Confusion, Evard's Black Tentacles, Phantasmal Killer, Modify Memory, Wall of Force, Disintegrate, Globe of Invulnerability</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -216,7 +216,7 @@
 			<attack>Crushing Hug|8|9d6+5</attack>
 			<attack>Per Turn| |9d6+5</attack>
 		</action>
-		<spells>disguise self, fog cloud, identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Disguise Self, Fog Cloud, Identify, Ray of Sickness, Hold Person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Apprentice Wizard</name>
@@ -254,7 +254,7 @@
 			<text>Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft, one target. Hit: 2 (1d4) piercing damage.</text>
 			<attack>Dagger|2|1d4</attack>
 		</action>
-		<spells>fire bolt, mending, prestidigitation, burning hands, disguise self, shield</spells>
+		<spells>Fire Bolt, Mending, Prestidigitation, Burning Hands, Disguise Self, Shield</spells>
 		<slots>2,0,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -307,7 +307,7 @@
 			<text>	While in a new form, the archdruid retains its game statistics and ability to speak, but its AC, movement modes, Strength, and Dexterity are replaced by those of the new form, and it gains any special senses, proficiencies, traits, actions, and reactions (except class features, legendary actions, and lair actions) that the new form has but that it lacks. It can cast its spells with verbal or somatic components in its new form.</text>
 			<text>	The new form's attacks count as magical for the purpose of overcoming resistances and immunity to nonmagical attacks.</text>
 		</action>
-		<spells>druidcraft, mending, poison spray, produce flame, cure wounds, entangle, faerie fire, speak with animals, animal messenger, beast sense, hold person, conjure animals, meld into stone, water breathing, dominate beast, locate creature, stoneskin, wall of fire, commune with nature, mass cure wounds, tree stride, heal, heroes' feast, sunbeam, fire storm, animal shapes, foresight</spells>
+		<spells>Druidcraft, Mending, Poison Spray, Produce Flame, Cure Wounds, Entangle, Faerie Fire, Speak with Animals, Animal Messenger, Beast Sense, Hold Person, Conjure Animals, Meld into Stone, Water Breathing, Dominate Beast, Locate Creature, Stoneskin, Wall of Fire, Commune with Nature, Mass Cure Wounds, Tree Stride, Heal, Heroes' Feast, Sunbeam, Fire Storm, Animal Shapes, Foresight</spells>
 		<slots>4,3,3,3,3,1,1,1,1</slots>
 	</monster>
 	<monster>
@@ -441,7 +441,7 @@
 			<name>Weakening Gaze</name>
 			<text>The babau targets one creature that it can see within 20 feet of it. The target must make a DC 13 Constitution saving throw. On a failed save, the target deals only half damage with weapon attacks that use Strength for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 		</action>
-		<spells>darkness, dispel magic, fear, heat metal, levitate</spells>
+		<spells>Darkness, Dispel Magic, Fear, Heat Metal, Levitate</spells>
 	</monster>
 	<monster>
 		<name>Banderhobb</name>
@@ -550,7 +550,7 @@
 			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one: target. Hit: 5 (1d6+2) piercing damage.</text>
 			<attack>Shortbow|4|1d6+2</attack>
 		</action>
-		<spells>friends, mage hand, vicious mockery, charm person, healing word, heroism, sleep, thunderwave, invisibility, shatter</spells>
+		<spells>Friends, Mage Hand, Vicious Mockery, Charm Person, Healing Word, Heroism, Sleep, Thunderwave, Invisibility, Shatter</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -613,7 +613,7 @@
 			<attack>Claws|6|1d8+4</attack>
 			<attack/>
 		</action>
-		<spells>levitate, minor illusion, pass without trace, charm person, dimension door, suggestion</spells>
+		<spells>Levitate, Minor Illusion, Pass without Trace, Charm Person, Dimension Door, Suggestion</spells>
 	</monster>
 	<monster>
 		<name>Bheur Hag</name>
@@ -716,7 +716,7 @@
 			<name>Maddening Feast</name>
 			<text>The hag feasts on the corpse of one enemy within 5 feet of her that died within the past minute. Each creature of the hag's choice that is within 60 feet of her and able to see her must succeed on a DC 15 Wisdom saving throw or be frightened of her for 1 minute. While frightened in this way, a creature is incapacitated, can't understand what others say, can't read, and speaks only in gibberish; the DM controls the creature's movement, which is erratic. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Maddening Feast for the next 24 hours.</text>
 		</action>
-		<spells>hold person, ray of frost, cone of cold, ice storm, wall of ice, control weather, identify, ray of sickness, hold person, locate object, bestow curse, counterspell, lightning bolt, phantasmal killer, polymorph, contact other plane, scrying, eyebite</spells>
+		<spells>Hold Person, Ray of Frost, Cone of Cold, Ice Storm, Wall of Ice, Control Weather, Identify, Ray of Sickness, hold person, Locate Object, Bestow Curse, Counterspell, Lightning Bolt, Phantasmal Killer, Polymorph, Contact Other Plane, Scrying, Eyebite</spells>
 	</monster>
 	<monster>
 		<name>Black Guard Drake</name>
@@ -813,7 +813,7 @@
 			<name>Dreadful Aspect (Recharges after a Short or Long Rest)</name>
 			<text>The blackguard exudes magical menace. Each enemy within 30 feet of the blackguard must succeed on a DC 13 Wisdom saving throw or be frightened for 1 minute. If a frightened target ends its turn more than 30 feet away from the blackguard, the tar get can repeat the saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>command, protection from evil and good, thunderous smite, branding smite, find steed, blinding smite, dispel magic</spells>
+		<spells>Command, Protection from Evil and Good, Thunderous Smite, Branding Smite, Find Steed, Blinding Smite, Dispel Magic</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1262,7 +1262,7 @@
 			<text>Ranged Weapon Attack: +5 to hit, range 30/60 ft., one Large or smaller creature. Hit: The target is restrained by webbing. As an action, the restrained target can make a DC 11 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; 5 hit points; vulnerability to fire damage; immunity to bludgeoning, poison, and psychic damage).</text>
 			<attack>Web|5|</attack>
 		</action>
-		<spells>guidance, mending, resistance, thaumaturgy, bane, healing word, sanctuary, shield of faith, hold person, spiritual weapon</spells>
+		<spells>Guidance, Mending, Resistance, Thaumaturgy, Bane, Healing Word, Sanctuary, Shield of Faith, Hold Person, Spiritual Weapon</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1329,7 +1329,7 @@
 			<name>Change Shape</name>
 			<text>The giant magically polymorphs into a beast or humanoid it has seen, or back into its true form. Any equipment the giant is wearing or carrying is absorbed by the new form. Its statistics, other than its size, are the same in each form. It reverts to its true form if it dies.</text>
 		</action>
-		<spells>detect magic, fog cloud, light, featherfall, fly, misty step, telekinesis, control weather, gaseous form, minor illusion, prestidigitation, vicious mockery, cure wounds, disguise self, silent image, Tasha's hideous laughter, invisibility, suggestion, major image, tongues</spells>
+		<spells>Detect Magic, Fog Cloud, Light, featherfall, Fly, Misty Step, Telekinesis, Control Weather, Gaseous Form, Minor Illusion, Prestidigitation, Vicious Mockery, Cure Wounds, Disguise Self, Silent Image, Tasha's Hideous Laughter, Invisibility, Suggestion, Major Image, Tongues</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1377,7 +1377,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4+2) piercing damage.</text>
 			<attack>Dagger|5|1d4+2</attack>
 		</action>
-		<spells>acid splash, mage hand, poison spray, prestidigitation, mage armor, magic missile, unseen servant, cloud of daggers, misty step, web, fireball, stinking cloud, Evard's black tentacles, stoneskin, cloudkill, conjure elemental</spells>
+		<spells>Acid Splash, Mage Hand, Poison Spray, Prestidigitation, Mage Armor, Magic Missile, Unseen Servant, Cloud of Daggers, Misty Step, Web, Fireball, Stinking Cloud, Evard's Black Tentacles, Stoneskin, Cloudkill, Conjure Elemental</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -1542,7 +1542,7 @@
 			<name>Darkness (Recharges after a Short or Long Rest)</name>
 			<text>The darkling elder casts darkness without any components. Wisdom is its spellcasting ability.</text>
 		</action>
-		<spells>darkness</spells>
+		<spells>Darkness</spells>
 	</monster>
 	<monster>
 		<name>Death Kiss</name>
@@ -1630,7 +1630,7 @@
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6+4) piercing damage.</text>
 			<attack>Gore|6|1d6+4</attack>
 		</action>
-		<spells>dancing lights</spells>
+		<spells>Dancing Lights</spells>
 	</monster>
 	<monster>
 		<name>Deep Scion</name>
@@ -1867,7 +1867,7 @@
 			<attack>Quarterstaff|2|1d6-1</attack>
 			<attack>Two Handed|2|1d8-1</attack>
 		</action>
-		<spells>fire bolt, light, mage hand, message, true strike, detect magic, feather fall, mage armor, detect thoughts, locate object, scorching ray, clairvoyance, fly, fireball, arcane eye, ice storm, stoneskin, Rary's telepathic bond, seeming, mass suggestion, true seeing, delayed blast fireball, teleport, maze</spells>
+		<spells>Fire Bolt, Light, Mage Hand, Message, True Strike, Detect Magic, Feather Fall, Mage Armor, Detect Thoughts, Locate Object, Scorching Ray, Clairvoyance, Fly, Fireball, Arcane Eye, Ice Storm, Stoneskin, Rary's Telepathic Bond, Seeming, Mass Suggestion, True Seeing, Delayed Blast Fireball, Teleport, Maze</spells>
 		<slots>4,3,3,3,2,1,1,1,0</slots>
 	</monster>
 	<monster>
@@ -1960,7 +1960,7 @@
 			<text>Melee Weapon Attack: +8 to hit, reach 10 ft, one target. Hit: 16 (2d10+5) slashing damage.</text>
 			<attack>Claws|8|2d10+5</attack>
 		</action>
-		<spells>darkness, confusion, dancing lights, faerie fire</spells>
+		<spells>Darkness, Confusion, Dancing Lights, Faerie Fire</spells>
 	</monster>
 	<monster>
 		<name>Elder Brain</name>
@@ -2047,7 +2047,7 @@
 			<name>Sever Psychic Link</name>
 			<text>The elder brain targets a creature within 120 feet of it with which it has a psychic link. The elder brain ends the link, causing the creature to have disadvantage on all ability checks, attack rolls, and saving throws until the end of the creature's next turn.</text>
 		</legendary>
-		<spells>detect thoughts, levitate, dominate monster, plane shift</spells>
+		<spells>Detect Thoughts, Levitate, Dominate Monster, Plane Shift</spells>
 	</monster>
 	<monster>
 		<name>Enchanter</name>
@@ -2096,7 +2096,7 @@
 			<text>The enchanter tries to magically divert an attack made against it, provided that the attacker is within 30 feet of it and visible to it. The enchanter must decide to do so before the attack hits or misses.</text>
 			<text>	The attacker must make a DC 14 Wisdom saving throw. On a failed save, the attacker targets the creature closest to it, other than the enchanter or itself. If multiple creatures are closest, the attacker chooses which one to target.</text>
 		</reaction>
-		<spells>friends, mage hand, mending, message, charm person, mage armor, magic missile, hold person, invisibility, suggestion, fireball, haste, tongues, dominate beast, stoneskin, hold monster</spells>
+		<spells>Friends, Mage Hand, Mending, Message, Charm Person, Mage Armor, Magic Missile, Hold Person, Invisibility, Suggestion, Fireball, Haste, Tongues, Dominate Beast, Stoneskin, Hold Monster</spells>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -2146,7 +2146,7 @@
 			<attack>Quarterstaff|3|1d6-1</attack>
 			<attack>Two Handed|3|1d8-1</attack>
 		</action>
-		<spells>fire bolt, light, prestidigitation, ray of frost, burning hands, mage armor, magic missile, mirror image, misty step, shatter, counterspell, fireball, lightning bolt, ice storm, stoneskin, Bigby's hand, cone of cold, chain lightning, wall of ice</spells>
+		<spells>Fire Bolt, Light, Prestidigitation, Ray of Frost, Burning Hands, Mage Armor, Magic Missile, Mirror Image, Misty Step, Shatter, Counterspell, Fireball, Lightning Bolt, Ice Storm, Stoneskin, Bigby's Hand, Cone of Cold, Chain Lightning, Wall of Ice</spells>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
 	</monster>
 	<monster>
@@ -2249,7 +2249,7 @@
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8+1) piercing damage.</text>
 			<attack>Morningstar|3|1d8+1</attack>
 		</action>
-		<spells>mage armor, burning hands, flaming sphere, hellish rebuke, scorching ray, fire bolt, guidance, light, mage hand, prestidigitation</spells>
+		<spells>Mage Armor, Burning Hands, Flaming Sphere, Hellish Rebuke, Scorching Ray, Fire Bolt, Guidance, Light, Mage Hand, Prestidigitation</spells>
 		<slots>0,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3231,7 +3231,7 @@
 			<attack>Quarterstaff|3|1d6+1</attack>
 			<attack>Two Handed|3|1d8+1</attack>
 		</action>
-		<spells>acid splash, fire bolt, ray of frost, shocking grasp, fog cloud, magic missile, thunderwave, gust of wind, Melf's acid arrow, scorching ray, fireball, fly, lightning bolt, ice storm</spells>
+		<spells>Acid Splash, Fire Bolt, Ray of Frost, Shocking Grasp, Fog Cloud, Magic Missile, Thunderwave, Gust of Wind, Melf's Acid Arrow, Scorching Ray, Fireball, Fly, Lightning Bolt, Ice Storm</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3287,7 +3287,7 @@
 			<name>Shadow Jaunt</name>
 			<text>The hobgoblin magically teleports, along with any equipment it is wearing or carrying, up to 30 feet to an unoccupied space it can see. Both the space it is leaving and its destination must be in dim light or darkness.</text>
 		</action>
-		<spells>minor illusion, prestidigitation, true strike, charm person, disguise self, expeditious retreat, silent image</spells>
+		<spells>Minor Illusion, Prestidigitation, True Strike, Charm Person, Disguise Self, Expeditious Retreat, Silent Image</spells>
 		<slots>3,0,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3392,7 +3392,7 @@
 			<name>Cast Spell (Costs 1-3 Actions)</name>
 			<text>The illithilich uses a spell slot to cast a 1st-, 2nd-, or 3rd-level spell that it has prepared. Doing so costs 1 legendary action per level of the spell.</text>
 		</legendary>
-		<spells>mage hand, prestidigitation, ray of frost, detect magic, magic missile, shield, thunderwave, detect thoughts, invisibility, levitate, Melf's acid arrow, mirror image, animate dead, counterspell, dispel magic, fireball, blight, dimension door, cloudkill, scrying, disintegrate, globe of invulnerability, finger of death, plane shift, dominate monster, power word stun, power word kill</spells>
+		<spells>Mage Hand, Prestidigitation, Ray of Frost, Detect Magic, Magic Missile, Shield, Thunderwave, Detect Thoughts, Invisibility, Levitate, Melf's Acid Arrow, Mirror Image, Animate Dead, Counterspell, Dispel Magic, Fireball, Blight, Dimension Door, Cloudkill, Scrying, Disintegrate, Globe of Invulnerability, Finger of Death, Plane Shift, Dominate Monster, Power Word Stun, Power Word Kill</spells>
 		<slots>4,3,3,3,3,1,1,1,1</slots>
 	</monster>
 	<monster>
@@ -3440,7 +3440,7 @@
 			<attack>Quarterstaff|1|1d6-1</attack>
 			<attack>Two Handed|1|1d8-1</attack>
 		</action>
-		<spells>dancing lights, mage hand, minor illusion, poison spray, color spray, disguise self, mage armor, magic missile, invisibility, mirror image, phantasmal force, major image, phantom steed, phantasmal killer</spells>
+		<spells>Dancing Lights, Mage Hand, Minor Illusion, Poison Spray, Color Spray, Disguise Self, Mage Armor, Magic Missile, Invisibility, Mirror Image, Phantasmal Force, Major Image, Phantom Steed, Phantasmal Killer</spells>
 		<slots>4,3,3,1,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3530,7 +3530,7 @@
 			<name>Move</name>
 			<text>The ki-rin moves up to its half its speed without provoking opportunity attacks.</text>
 		</legendary>
-		<spells>gaseous form, major image, wind walk, create food and water, light, mending, sacred flame, spare the dying, thaumaturgy, command, cure wounds, detect evil and good, protection from evil and good, sanctuary, calm emotions, lesser restoration, silence, dispel magic, remove curse, sending, banishment, freedom of movement, guardian of faith, greater restoration, mass cure wounds, scrying, heroes' feast, true seeing, etherealness, plane shift, control weather, true resurrection</spells>
+		<spells>Gaseous Form, Major Image, Wind Walk, Create Food and Water, Light, Mending, Sacred Flame, Spare the Dying, Thaumaturgy, Command, Cure Wounds, Detect Evil and Good, Protection from Evil and Good, Sanctuary, Calm Emotions, Lesser Restoration, Silence, Dispel Magic, Remove Curse, Sending, Banishment, Freedom of Movement, Guardian of Faith, Greater Restoration, Mass Cure Wounds, Scrying, Heroes' Feast, True Seeing, Etherealness, Plane Shift, Control Weather, True Resurrection</spells>
 		<slots>4,3,3,3,3,1,1,1,1</slots>
 	</monster>
 	<monster>
@@ -3700,7 +3700,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 it, one target. Hit: 4 (1d4+2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>fire bolt, mage hand, mending, poison spray, charm person, chromatic orb, expeditious retrea, scorching ray</spells>
+		<spells>Fire Bolt, Mage Hand, Mending, Poison Spray, Charm Person, Chromatic Orb, expeditious retrea, Scorching Ray</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3763,7 +3763,7 @@
 			<attack>Rock|9|2d8+6</attack>
 			<attack>On Ground|9|4d8+6</attack>
 		</action>
-		<spells>commune with nature, meld into stone, stone shape, conjure elemental, Otto's irresistible dance</spells>
+		<spells>Commune with Nature, Meld into Stone, Stone Shape, Conjure Elemental, Otto's Irresistible Dance</spells>
 	</monster>
 	<monster>
 		<name>Kraken Priest</name>
@@ -3810,7 +3810,7 @@
 			<name>Voice of the Kraken (Recharges after a Short or Long Rest)</name>
 			<text>A kraken speaks through the priest with a thunderous voice audible within 300 feet. Creatures of the priest's choice that can hear the kraken's words (which are spoken in Abyssal, Infernal, or Primordial) must succeed on a DC 14 Charisma saving throw or be frightened for 1 minute. A frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 		</action>
-		<spells>command, create or destroy water, control water, darkness, water breathing, water walk, call lightning, Evard's black tentacles</spells>
+		<spells>Command, Create or Destroy Water, Control Water, Darkness, Water Breathing, Water Walk, Call Lightning, Evard's Black Tentacles</spells>
 	</monster>
 	<monster>
 		<name>Leucrotta</name>
@@ -4118,7 +4118,7 @@
 			<text>The mind flayer magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 15 Intelligence saving throw or take 22 (4d8+4) psychic damage and be stunned for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 			<attack>Mind Blast||4d8+4</attack>
 		</action>
-		<spells>guidance, mage hand, vicious mockery, true strike, charm person, command, comprehend languages, sanctuary, crown of madness, phantasmal force, see invisibility, clairvoyance, fear, meld into stone, confusion, stone shape, scrying, telekinesis</spells>
+		<spells>Guidance, Mage Hand, Vicious Mockery, True Strike, Charm Person, Command, Comprehend Languages, Sanctuary, Crown of Madness, Phantasmal Force, See Invisibility, Clairvoyance, Fear, Meld into Stone, Confusion, Stone Shape, Scrying, Telekinesis</spells>
 	</monster>
 	<monster>
 		<name>Mindwitness</name>
@@ -4344,7 +4344,7 @@
 			<text>Melee Spell Attack: +7 to hit, reach 5 ft., one creature. Hit: 5 (2d4) necrotic damage.</text>
 			<attack>Withering Touch|7|2d4</attack>
 		</action>
-		<spells>chill touch, dancing lights, mage hand, mending, false life, mage armor, ray of sickness, blindness/deafness, ray of enfeeblement, web, animate dead, bestow curse, vampiric touch, blight, dimension door, stoneskin, Bigby's hand, cloudkill, circle of death</spells>
+		<spells>Chill Touch, Dancing Lights, Mage Hand, Mending, False Life, Mage Armor, Ray of Sickness, Blindness/Deafness, Ray of Enfeeblement, Web, Animate Dead, Bestow Curse, Vampiric Touch, Blight, Dimension Door, Stoneskin, Bigby's Hand, Cloudkill, Circle of Death</spells>
 		<slots>4,3,3,3,3,2,1,0,0</slots>
 	</monster>
 	<monster>
@@ -4497,7 +4497,7 @@
 			<name>Enslave (Recharges after a Short or Long Rest)</name>
 			<text>The neogi targets one creature it can see within 30 feet of it. The target must succeed on a DC 14 Wisdom saving throw or be magicallcharmed by the neogi for 1 day, or until the neogi dies or is more than 1 mile from the target. The charmed target obeys the neogi's commands and can't take reactions, and the neogi and the target can communicate telepathically with each other at a distance of up to 1 mile. Whenever the charmed target takes damage, it can repeat the saving throw, ending the effect on itself on a success.</text>
 		</action>
-		<spells>eldritch blast, guidance, mage hand, minor illusion, prestidigitation, vicious mockery, arms of Hadar, counterspell, dimension door, fear, hold person, hunger of Hadar, invisibility, unseen servant</spells>
+		<spells>Eldritch Blast, Guidance, Mage Hand, Minor Illusion, Prestidigitation, Vicious Mockery, Arms of Hadar, Counterspell, Dimension Door, Fear, Hold Person, Hunger of Hadar, Invisibility, Unseen Servant</spells>
 		<slots>0,0,0,4,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -4551,7 +4551,7 @@
 			<text>The neothelid exhales acid in a 60-foot cone. Each creature in that area must make a DC 18 Dexterity saving throw, taking 35 (10d6) acid damage on a failed save, or half as much damage on a successful one.</text>
 			<attack>Acid Breath | |10d6</attack>
 		</action>
-		<spells>levitate, confusion, feeblemind, telekinesis</spells>
+		<spells>Levitate, Confusion, Feeblemind, Telekinesis</spells>
 	</monster>
 	<monster>
 		<name>Nilbog</name>
@@ -4606,7 +4606,7 @@
 			<text>In response to another creature dealing damage to the nilbog, the nilbog reduces the damage to 0 and regains 1d6 hit points.</text>
 			<attack>Reversal of Fortune| |1d6</attack>
 		</reaction>
-		<spells>mage hand, Tasha's hideous laughter, vicious mockery, confusion</spells>
+		<spells>Mage Hand, Tasha's Hideous Laughter, Vicious Mockery, Confusion</spells>
 	</monster>
 	<monster>
 		<name>Orc Blade of Ilneval</name>
@@ -4712,7 +4712,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8+2) slashing damage.</text>
 			<attack>Claw|4|1d8+2</attack>
 		</action>
-		<spells>guidance, mending, resistance, thaumaturgy, bane, cure wounds, guiding bolt, augury, warding bond, bestow curse, create food and water</spells>
+		<spells>Guidance, Mending, Resistance, Thaumaturgy, Bane, Cure Wounds, Guiding Bolt, Augury, Warding Bond, Bestow Curse, Create Food and Water</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -4760,7 +4760,7 @@
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 9 (2d8) necrotic damage.</text>
 			<attack>Touch of the White Hand|3|2d8</attack>
 		</action>
-		<spells>guidance, mending, resistance, thaumaturgy, bane, detect magic, inflict wounds, protection from evil and good, blindness/deafness, silence</spells>
+		<spells>Guidance, Mending, Resistance, Thaumaturgy, Bane, Detect Magic, Inflict Wounds, Protection from Evil and Good, Blindness/Deafness, Silence</spells>
 		<slots>4,3,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -4871,7 +4871,7 @@
 			<name>Veil of Shargaas (Recharges after a Short or Long Rest)</name>
 			<text>The orc casts darkness without any components. Wisdom is its spellcasting ability.</text>
 		</action>
-		<spells>darkness</spells>
+		<spells>Darkness</spells>
 	</monster>
 	<monster>
 		<name>Ox</name>
@@ -5618,7 +5618,7 @@
 			<attack>Bites|5|4d6</attack>
 			<attack>Half Hit Points|5|2d6</attack>
 		</action>
-		<spells>command, comprehend languages, detect thoughts, confusion, dominate monster</spells>
+		<spells>Command, Comprehend Languages, Detect Thoughts, Confusion, Dominate Monster</spells>
 	</monster>
 	<monster>
 		<name>Swarm of Rot Grubs</name>
@@ -5900,7 +5900,7 @@
 			<attack>Quarterstaff|2|1d6-1</attack>
 			<attack>Two Handed|2|1d8-1</attack>
 		</action>
-		<spells>light, mending, prestidigitation, ray of frost, chromatic orb, expeditious retreat, mage armor, alter self, hold person, knock, blink, fireball, slow, polymorph, stoneskin, telekinesis</spells>
+		<spells>Light, Mending, Prestidigitation, Ray of Frost, Chromatic Orb, Expeditious Retreat, Mage Armor, Alter Self, Hold Person, Knock, Blink, Fireball, Slow, Polymorph, Stoneskin, Telekinesis</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6001,7 +6001,7 @@
 			<text>The ulitharid magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a DC 17 Intelligence saving throw or take 31 (4d12+5) psychic damage and be stunned for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 			<attack>Mind Blast| |4d12+5</attack>
 		</action>
-		<spells>detect thoughts, levitate, confusion, dominate monster, eyebite, feeblemind, mass suggestion, plane shift, project image, scrying, telekinesis</spells>
+		<spells>Detect Thoughts, Levitate, Confusion, Dominate Monster, Eyebite, Feeblemind, Mass Suggestion, Plane Shift, Project Image, Scrying, Telekinesis</spells>
 	</monster>
 	<monster>
 		<name>Vargouille</name>
@@ -6228,7 +6228,7 @@
 			<name>Guided Strike (Recharges after a Short or Long Rest)</name>
 			<text>The priest grants a +10 bonus to an attack roll made by itself or another creature within 30 feet of it. The priest can make this choice after the roll is made but before it hits or misses.</text>
 		</reaction>
-		<spells>light, mending, sacred flame, spare the dying, divine favor, guiding bolt, healing word, shield of faith, lesser restoration, magic weapon, prayer of healing, silence, spiritual weapon, beacon of hope, crusader's mantle, dispel magic, revivify, spirit guardians, water wall, banishment, freedom of movement, guardian of faith, stoneskin, flame strike, mass cure wounds, hold monster</spells>
+		<spells>Light, Mending, Sacred Flame, Spare the Dying, Divine Favor, Guiding Bolt, Healing Word, Shield of Faith, Lesser Restoration, Magic Weapon, Prayer of Healing, Silence, Spiritual Weapon, Beacon of Hope, Crusader's Mantle, Dispel Magic, Revivify, Spirit Guardians, water wall, Banishment, Freedom of Movement, Guardian of Faith, Stoneskin, Flame Strike, Mass Cure Wounds, Hold Monster</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6277,7 +6277,7 @@
 			<name>Misty Escape (Recharges after a Short or Long Rest)</name>
 			<text>In response to taking damage, the warlock turns invisible and teleports up to 60 feet to an unoccupied space it can see. It remains invisible until the start of its next turn or until it attacks, makes a damage roll, or casts a spell.</text>
 		</reaction>
-		<spells>disguise self, mage armor, silent image, speak with animals, conjure fey, dancing lights, eldritch blast, friends, mage hand, minor illusion, prestidigitation, vicious mockery, blink, charm person, dimension door, dominate beast, faerie fire, fear, hold monster, misty step, phantasmal force, seeming, sleep</spells>
+		<spells>Disguise Self, Mage Armor, Silent Image, Speak with Animals, Conjure Fey, Dancing Lights, Eldritch Blast, Friends, Mage Hand, Minor Illusion, Prestidigitation, Vicious Mockery, Blink, Charm Person, Dimension Door, Dominate Beast, Faerie Fire, Fear, Hold Monster, Misty Step, Phantasmal Force, Seeming, Sleep</spells>
 		<slots>0,0,0,0,5,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6326,7 +6326,7 @@
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage plus 10 (3d6) fire damage.</text>
 			<attack>Mace|3|1d6+3d6</attack>
 		</action>
-		<spells>alter self, false life, levitate, mage armor, silent image, feeblemind, finger of death, plane shift, eldritch blast, fire bolt, friends, mage hand, minor illusion, prestidigitation, shocking grasp, banishment, burning hands, flame strike, hellish rebuke, magic circle, scorching ray, scrying, stinking cloud, suggestion, wall of fire</spells>
+		<spells>Alter Self, False Life, Levitate, Mage Armor, Silent Image, Feeblemind, Finger of Death, Plane Shift, Eldritch Blast, Fire Bolt, Friends, Mage Hand, Minor Illusion, Prestidigitation, Shocking Grasp, Banishment, Burning Hands, Flame Strike, Hellish Rebuke, Magic Circle, Scorching Ray, Scrying, Stinking Cloud, Suggestion, Wall of Fire</spells>
 		<slots>0,0,0,0,4,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6375,7 +6375,7 @@
 			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4+2) piercing damage.</text>
 			<attack>Dagger|5|1d4+2</attack>
 		</action>
-		<spells>detect magic, jump, levitate, mage armor, speak with dead, arcane gate, true seeing, chill touch, eldritch blast, guidance, mage hand, minor illusion, prestidigitation, shocking grasp, armor of Agathys, arms of Hadar, crown of madness, clairvoyance, contact other plane, detect thoughts, dimension door, dissonant whispers, dominate beast, telekinesis, vampiric touch</spells>
+		<spells>Detect Magic, Jump, Levitate, Mage Armor, Speak with Dead, Arcane Gate, True Seeing, Chill Touch, Eldritch Blast, Guidance, Mage Hand, Minor Illusion, Prestidigitation, Shocking Grasp, Armor of Agathys, Arms of Hadar, Crown of Madness, Clairvoyance, Contact Other Plane, Detect Thoughts, Dimension Door, Dissonant Whispers, Dominate Beast, Telekinesis, Vampiric Touch</spells>
 		<slots>0,0,0,0,3,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6669,7 +6669,7 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6+2) slashing damage.</text>
 			<attack>Scimitar|4|1d6+2</attack>
 		</action>
-		<spells>detect magic, mage armor, burning hands, expeditious retreat, invisibility, scorching ray</spells>
+		<spells>Detect Magic, Mage Armor, Burning Hands, Expeditious Retreat, Invisibility, Scorching Ray</spells>
 		<slots>0,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6800,7 +6800,7 @@
 			<text>Melee Weapon Attack: +10 to hit, reach 10 ft., one creature. Hit: 27 (6d6+6) piercing damage plus 14 (4d6) poison damage.</text>
 			<attack>Flurry of Bites|10|6d6+6+4d6</attack>
 		</action>
-		<spells>animal friendship, darkness, entangle, fear, haste, suggestion, polymorph, divine word</spells>
+		<spells>Animal Friendship, Darkness, Entangle, Fear, Haste, Suggestion, Polymorph, Divine Word</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Broodguard</name>
@@ -6935,7 +6935,7 @@
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6+3) slashing damage.</text>
 			<attack>Scimitar|5|1d6+3</attack>
 		</action>
-		<spells>animal friendship, suggestion, eldritch blast, friends, message, minor illusion, poison spray, prestidigitation, charm person, crown of madness, detect thoughts, expeditious retreat, fly, hypnotic pattern, illusory script</spells>
+		<spells>Animal Friendship, Suggestion, Eldritch Blast, Friends, Message, Minor Illusion, Poison Spray, Prestidigitation, Charm Person, Crown of Madness, Detect Thoughts, Expeditious Retreat, Fly, Hypnotic Pattern, Illusory Script</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Nightmare Speaker</name>
@@ -7013,7 +7013,7 @@
 			<text>The yuan-ti taps into the nightmares of a creature it can see within 60 feet of it and creates an illusory, immobile manifestation of the creature's deepest fears, visible only to that creature. The target must make a DC 13 Intelligence saving throw. On a failed save, the target takes 11 (2d10) psychic damage and is frightened of the manifestation, believing it to be real. The yuan-ti must concentrate to maintain the illusion (as if concentrating on a spell), which lasts for up to 1 minute and can't be harmed. The target can repeat the saving throw at the end of each of its turns, ending the illusion on a success, or taking 11 (2d10) psychic damage on a failure.</text>
 			<attack>Nightmare| |2d10</attack>
 		</action>
-		<spells>animal friendship, suggestion, chill touch, eldritch blast, mage hand, message, poison spray, prestidigitation, arms of Hadar, darkness, fear, hex, hold person, hunger of Hadar, witch bolt</spells>
+		<spells>Animal Friendship, Suggestion, Chill Touch, Eldritch Blast, Mage Hand, Message, Poison Spray, Prestidigitation, Arms of Hadar, Darkness, Fear, Hex, Hold Person, Hunger of Hadar, Witch Bolt</spells>
 	</monster>
 	<monster>
 		<name>Yuan-ti Pit Master</name>
@@ -7085,6 +7085,6 @@
 			<name>Merrshaulk's Slumber (1/Day)</name>
 			<text>The yuan-ti targets up to five creatures that it can see within 60 feet of it. Each target must succeed on a DC 13 Constitution saving throw or fall into a magical sleep and be unconscious for 10 minutes. A sleeping target awakens if it takes damage or if someone uses an action to shake or slap it awake. This magical sleep has no effect on a creature immune to being charmed.</text>
 		</action>
-		<spells>animal friendship, suggestion, eldritch blast, friends, guidance, mage hand, message, poison spray, command, counterspell, hellish rebuke, invisibility, misty step, unseen servant, vampiric touch</spells>
+		<spells>Animal Friendship, Suggestion, Eldritch Blast, Friends, Guidance, Mage Hand, Message, Poison Spray, Command, Counterspell, Hellish Rebuke, Invisibility, Misty Step, Unseen Servant, Vampiric Touch</spells>
 	</monster>
 </compendium>

--- a/Bestiary/Volo's Guide to Monsters.xml
+++ b/Bestiary/Volo's Guide to Monsters.xml
@@ -48,7 +48,7 @@
 			<attack>Quarterstaff|3|1d6-l</attack>
 			<attack>Two Handed|3|1d8-1</attack>
 		</action>
-		<spells>blade ward. dancing lights, Mending, Message, Ray of Frost, Alarm, Mage Armor, Magic Missile, Shield, Arcane Lock, Invisibility, Counterspell, Dispel Magic, Fireball, Banishment, Stoneskin, Cone of Cold, Wall of Force, Flesh to Stone, Globe of Invulnerability, symbol teleport</spells>
+		<spells>Blade Ward, Dancing Lights, Mending, Message, Ray of Frost, Alarm, Mage Armor, Magic Missile, Shield, Arcane Lock, Invisibility, Counterspell, Dispel Magic, Fireball, Banishment, Stoneskin, Cone of Cold, Wall of Force, Flesh to Stone, Globe of Invulnerability, Symbol, Teleport</spells>
 		<slots>4,3,3,3,2,1,1,0,0</slots>
 	</monster>
 	<monster>
@@ -1294,7 +1294,7 @@
 			<name>Innate Spellcasting</name>
 			<text>The giant's innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:</text>
 			<text>At will: detect magic, fog cloud, light</text>
-			<text>3/day each: featherfall, fly, misty step, telekinesis</text>
+			<text>3/day each: feather fall, fly, misty step, telekinesis</text>
 			<text>1/day each: control weather, gaseous form</text>
 		</trait>
 		<trait>
@@ -1329,7 +1329,7 @@
 			<name>Change Shape</name>
 			<text>The giant magically polymorphs into a beast or humanoid it has seen, or back into its true form. Any equipment the giant is wearing or carrying is absorbed by the new form. Its statistics, other than its size, are the same in each form. It reverts to its true form if it dies.</text>
 		</action>
-		<spells>Detect Magic, Fog Cloud, Light, featherfall, Fly, Misty Step, Telekinesis, Control Weather, Gaseous Form, Minor Illusion, Prestidigitation, Vicious Mockery, Cure Wounds, Disguise Self, Silent Image, Tasha's Hideous Laughter, Invisibility, Suggestion, Major Image, Tongues</spells>
+		<spells>Detect Magic, Fog Cloud, Light, Feather Fall, Fly, Misty Step, Telekinesis, Control Weather, Gaseous Form, Minor Illusion, Prestidigitation, Vicious Mockery, Cure Wounds, Disguise Self, Silent Image, Tasha's Hideous Laughter, Invisibility, Suggestion, Major Image, Tongues</spells>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -3700,7 +3700,7 @@
 			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 it, one target. Hit: 4 (1d4+2) piercing damage.</text>
 			<attack>Dagger|4|1d4+2</attack>
 		</action>
-		<spells>Fire Bolt, Mage Hand, Mending, Poison Spray, Charm Person, Chromatic Orb, expeditious retrea, Scorching Ray</spells>
+		<spells>Fire Bolt, Mage Hand, Mending, Poison Spray, Charm Person, Chromatic Orb, Expeditious Retreat, Scorching Ray</spells>
 		<slots>4,2,0,0,0,0,0,0,0</slots>
 	</monster>
 	<monster>
@@ -6211,7 +6211,7 @@
 			<text>Cantrips (at will): light, mending, sacred flame, spare the dying</text>
 			<text>1st level (4 slots): divine favor, guiding bolt, healing word, shield of faith</text>
 			<text>2nd level (3 slots): lesser restoration, magic weapon, prayer of healing, silence, spiritual weapon</text>
-			<text>3rd level (3 slots): beacon of hope, crusader's mantle, dispel magic, revivify, spirit guardians, water wall</text>
+			<text>3rd level (3 slots): beacon of hope, crusader's mantle, dispel magic, revivify, spirit guardians, water walk</text>
 			<text>4th level (3 slots): banishment, freedom of movement, guardian of faith, stoneskin</text>
 			<text>5th level (1 slot): flame strike, mass cure wounds, hold monster</text>
 		</trait>
@@ -6228,7 +6228,7 @@
 			<name>Guided Strike (Recharges after a Short or Long Rest)</name>
 			<text>The priest grants a +10 bonus to an attack roll made by itself or another creature within 30 feet of it. The priest can make this choice after the roll is made but before it hits or misses.</text>
 		</reaction>
-		<spells>Light, Mending, Sacred Flame, Spare the Dying, Divine Favor, Guiding Bolt, Healing Word, Shield of Faith, Lesser Restoration, Magic Weapon, Prayer of Healing, Silence, Spiritual Weapon, Beacon of Hope, Crusader's Mantle, Dispel Magic, Revivify, Spirit Guardians, water wall, Banishment, Freedom of Movement, Guardian of Faith, Stoneskin, Flame Strike, Mass Cure Wounds, Hold Monster</spells>
+		<spells>Light, Mending, Sacred Flame, Spare the Dying, Divine Favor, Guiding Bolt, Healing Word, Shield of Faith, Lesser Restoration, Magic Weapon, Prayer of Healing, Silence, Spiritual Weapon, Beacon of Hope, Crusader's Mantle, Dispel Magic, Revivify, Spirit Guardians, Water Walk, Banishment, Freedom of Movement, Guardian of Faith, Stoneskin, Flame Strike, Mass Cure Wounds, Hold Monster</spells>
 		<slots>4,3,3,3,1,0,0,0,0</slots>
 	</monster>
 	<monster>

--- a/Homebrew/Classes/Cleric/Cleric (Madness).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Madness).xml
@@ -9,7 +9,7 @@
 				<text/>
 				<text>Madness Domain Spells: At each indicated cleric level, add the listed spells to your spells prepared. They do not count towards your limit.</text>
 				<text/>
-				<text>1st - dissonant whispers, hideous laughter</text>
+				<text>1st - dissonant whispers, Tasha's hideous laughter</text>
 				<text/>
 				<text>3rd - crown of madness, suggestion</text>
 				<text/>

--- a/Homebrew/Classes/Sorcerer/Sorcerer (Spell Surge).xml
+++ b/Homebrew/Classes/Sorcerer/Sorcerer (Spell Surge).xml
@@ -30,7 +30,7 @@
 				<text>14. You and all creatures within 30 feet of you gain vulnerability to physical damage for the next minute.</text>
 				<text>15. You cast Gaseous Form centered on yourself.</text>
 				<text>16. You cast Fireball at 3rd level centered on yourself.</text>
-				<text>17. You cast Otto's Irresistable Dance centered on yourself.</text>
+				<text>17. You cast Otto's Irresistible Dance centered on yourself.</text>
 				<text>18. You cast Reverse Gravity centered on yourself.</text>
 				<text>19. Your mind is pulled into a dark labyrinth, as you become affected by the Maze spell.</text>
 				<text>20. Roll a d10: on a roll of 10, you are afflicted with vampirism; on a 1, you are cursed with lycanthropy.</text>
@@ -44,7 +44,7 @@
 				<text>5. For the next minute, you can only speak in Halo-esque Gregorian chants.</text>
 				<text>6. A target you choose immediately takes an extra Action.</text>
 				<text>7. You cast Gaseous Form centered on yourself.</text>
-				<text>8. You cast Otto's Irresistable Dance centered on yourself.</text>
+				<text>8. You cast Otto's Irresistible Dance centered on yourself.</text>
 				<text>9. You gain temporary hit points equal to your level.</text>
 				<text>10. A spectral shield hovers near you for the next minute, granting you a +2 to AC and immunity to Magic Missile.</text>
 				<text>11. For one minute, you can cast Misty Step without expending a spell slot.</text>

--- a/Homebrew/Monsters/Book of the Righteous.xml
+++ b/Homebrew/Monsters/Book of the Righteous.xml
@@ -116,7 +116,7 @@
 		<trait>
 			<name>Innate Spellcasting</name>
 			<text>The handmaid's spellcasting ability is Wisdom (spell save DC 19). The handmaid can innately cast the following spells, requiring only verbal components.</text>
-			<text>3/day: confusion, dimension door, dominate person, greater invisibility, hideous laughter, polymorph</text>
+			<text>3/day: confusion, dimension door, dominate person, greater invisibility, Tasha's hideous laughter, polymorph</text>
 			<text>1/day: dominate monster, mislead, plane shift, teleport</text>
 		</trait>
 		<trait>

--- a/Homebrew/Monsters/Strongholds and Followers.xml
+++ b/Homebrew/Monsters/Strongholds and Followers.xml
@@ -294,14 +294,14 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>Oregg Steeltwister is a 5th-level spellcaster. His spellcasting ability modifier is Charisma (spell save DC 15, +7 to hit with spell attacks). He has the following sorcerer spells prepared:</text>
-			<text>Cantrips (at will): firebolt, message, poison spray, true strike</text>
+			<text>Cantrips (at will): fire bolt, message, poison spray, true strike</text>
 			<text>1st level (4 slots): magic missile, shield</text>
 			<text>2nd level (3 slots): heat metal</text>
 			<text>3rd level (2 slots): fly, fireball</text>
 		</trait>
 		<spellAbility>Charisma</spellAbility>
 		<slots>4,3,2,0,0,0,0,0,0</slots>
-		<spells>Firebolt, Message, Poison Spray, True Strike, Magic Missile, Shield, Heat Metal, Fly, Fireball</spells>
+		<spells>Fire Bolt, Message, Poison Spray, True Strike, Magic Missile, Shield, Heat Metal, Fly, Fireball</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Oregg makes two longsword attacks and can cast a cantrip as a bonus action.</text>
@@ -419,12 +419,12 @@
 			<name>Innate Spellcasting</name>
 			<text>Sir Pelliton has gained the power to cast dark magic. All spells he casts with this feature are cast as if using a 5th-level spell slot, and he casts cantrips as if he were an 11th-level warlock. His spellcasting ability is Wisdom (DC 16, +8 to hit with spell attacks).</text>
 			<text>At will: acid splash, eldritch blast (3 beams), minor illusion, hellish rebuke</text>
-			<text>5/day: branding smite, black tentacles, counterspell, dimension door, hold person</text>
+			<text>5/day: branding smite, Evard's black tentacles, counterspell, dimension door, hold person</text>
 			<text>1/day each: cone of cold, eyebite, mass suggestion</text>
 		</trait>
 		<spellAbility>Wisdom</spellAbility>
 		<slots>0,0,0,0,0,0,0,0,0</slots>
-		<spells>Acid Splash, Eldritch Blast, Minor Illusion, Hellish Rebuke, Branding Smite, Black Tentacles, Counterspell, Dimension Door, Hold Person, Cone of Cold, Eyebite, Mass Suggestion</spells>
+		<spells>Acid Splash, Eldritch Blast, Minor Illusion, Hellish Rebuke, Branding Smite, Evard's Black Tentacles, Counterspell, Dimension Door, Hold Person, Cone of Cold, Eyebite, Mass Suggestion</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Sir Pelliton makes three melee attacks or makes two melee attacks and casts eldritch blast.</text>
@@ -1228,12 +1228,12 @@
 			<text>1st level (4 slots): mage armor, magic missile, sleep</text>
 			<text>2nd level (3 slots): ray of enfeeblement, mirror image</text>
 			<text>3rd level (3 slots): lightning bolt, haste</text>
-			<text>4th level (3 slots): black tentacles, blight</text>
+			<text>4th level (3 slots): Evard's black tentacles, blight</text>
 			<text>5th level (2 slots): cloudkill</text>
 		</trait>
 		<spellAbility>Intelligence</spellAbility>
 		<slots>4,3,3,3,2,0,0,0,0</slots>
-		<spells>Mage Hand, Minor Illusion, Ray of Frost, Mage Armor, Magic Missile, Sleep, Ray of Enfeeblement, Mirror Image, Lightning Bolt, Haste, Black Tentacles, Blight, Cloudkill</spells>
+		<spells>Mage Hand, Minor Illusion, Ray of Frost, Mage Armor, Magic Missile, Sleep, Ray of Enfeeblement, Mirror Image, Lightning Bolt, Haste, Evard's Black Tentacles, Blight, Cloudkill</spells>
 		<action>
 			<name>Multiattack</name>
 			<text>Lord Rall makes two melee attacks with the Staff of Changing.</text>

--- a/Homebrew/Monsters/Tal'dorei Campaign Setting.xml
+++ b/Homebrew/Monsters/Tal'dorei Campaign Setting.xml
@@ -747,7 +747,7 @@
 			<name>Spellcasting</name>
 			<text>The remnant cultist is an 11th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The cultist has the following wizard spells prepared:</text>
 			<text>Cantrips (at will): chill touch, message, minor illusion, prestidigitation, ray of frost</text>
-			<text>1st level (4 slots): detect magic, hideous laughter, mage armor, shield</text>
+			<text>1st level (4 slots): detect magic, Tasha's hideous laughter, mage armor, shield</text>
 			<text>2nd level (3 slots): detect thoughts, suggestion</text>
 			<text>3rd level (3 slots): counterspell, fear, vampiric touch</text>
 			<text>4th level (3 slots): greater invisibility, phantasmal killer</text>
@@ -765,7 +765,7 @@
 		</trait>
 		<spellAbility>Intelligence</spellAbility>
 		<slots>4,3,3,3,2,1,0,0,0</slots>
-		<spells>Chill Touch, Message, Minor Illusion, Prestidigitation, Ray of Frost, Detect Magic, Hideous Laughter, Mage Armor, Shield, Detect Thoughts, Suggestion, Counterspell, Fear, Vampiric Touch, Greater Invisibility, Phantasmal Killer, Dream, Mislead, Circle of Death</spells>
+		<spells>Chill Touch, Message, Minor Illusion, Prestidigitation, Ray of Frost, Detect Magic, Tasha's Hideous Laughter, Mage Armor, Shield, Detect Thoughts, Suggestion, Counterspell, Fear, Vampiric Touch, Greater Invisibility, Phantasmal Killer, Dream, Mislead, Circle of Death</spells>
 		<action>
 			<name>Dagger of Wounding</name>
 			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft., range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage. Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>

--- a/Homebrew/Monsters/Tome of Beasts.xml
+++ b/Homebrew/Monsters/Tome of Beasts.xml
@@ -4287,7 +4287,7 @@
 		<trait>
 			<name>Innate Spellcasting</name>
 			<text>Qorgeth's innate spellcasting ability is Charisma (spell save DC 19). It can innately cast the following spells, requiring no material or somatic components.</text>
-			<text>At will: detect magic, black tentacles</text>
+			<text>At will: detect magic, Evard's black tentacles</text>
 			<text>3/day each: dispel magic, fear, insect plague (biting worms)</text>
 			<text>1/day each: earthquake, teleport</text>
 		</trait>
@@ -7618,7 +7618,7 @@
 			<name>Innate Spellcasting</name>
 			<text>The drake's innate casting ability is Charisma (spell save DC 13, +5 to hit with spell attacks). It can innately cast the following spells, requiring no material components:</text>
 			<text>At will: friends, vicious mockery</text>
-			<text>5/day each: calm emotions, dissonant whispers, ray of sickness, hideous laughter</text>
+			<text>5/day each: calm emotions, dissonant whispers, ray of sickness, Tasha's hideous laughter</text>
 			<text>3/day each: confusion, invisibility</text>
 		</trait>
 		<trait>
@@ -12914,7 +12914,7 @@
 			<text>The hundun's innate spellcasting ability is Wisdom (spell save DC 17). It can cast the following spells, requiring no material components:</text>
 			<text>Constant: confusion (always centered on the hundun), detect thoughts</text>
 			<text>At will: create or destroy water, dancing lights, mending, prestidigitation</text>
-			<text>3/day each: compulsion, dimension door, black tentacles, irresistible dance</text>
+			<text>3/day each: compulsion, dimension door, Evard's black tentacles, irresistible dance</text>
 			<text>1/day each: awaken, creation, heroes' feast, magnificent mansion, plant growth, reincarnate, stone shape</text>
 		</trait>
 		<trait>
@@ -13886,7 +13886,7 @@ whirlwind by using its action to repeat the saving throw; on a success, it moves
 			<name>Innate Spellcasting</name>
 			<text>The leshy's innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components:</text>
 			<text>At will: animal friendship, pass without trace, speak with animals</text>
-			<text>1/day each: entangle, plant growth, shillelagh, speak with plants, hideous laughter</text>
+			<text>1/day each: entangle, plant growth, shillelagh, speak with plants, Tasha's hideous laughter</text>
 		</trait>
 		<trait>
 			<name>Camouflage</name>
@@ -17286,7 +17286,7 @@ whirlwind by using its action to repeat the saving throw; on a success, it moves
 			<text>The scheznyki's innate spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). It can innately cast the following spells, requiring no material components:</text>
 			<text>At will: dancing lights, darkness, detect evil and good, faerie fire, invisibility*, fly*, mage hand, ray of frost (*only when wearing a vanisher hat)</text>
 			<text>5/day each: magic missile, ray of enfeeblement, silent image</text>
-			<text>3/day each: locate object (radius 3,000 ft to locate a vanisher hat), hideous laughter, web</text>
+			<text>3/day each: locate object (radius 3,000 ft to locate a vanisher hat), Tasha's hideous laughter, web</text>
 			<text>1/day each: dispel magic, dominate person, hold person</text>
 		</trait>
 		<trait>
@@ -20279,7 +20279,7 @@ whirlwind by using its action to repeat the saving throw; on a success, it moves
 			<name>Innate Spellcasting</name>
 			<text>The umbral vampire's innate spellcasting ability is Charisma (spell save DC 15). The umbral vampire can innately cast the following spells, requiring no material components:</text>
 			<text>At will: mirror image, plane shift (plane of shadows only)</text>
-			<text>1/day each: bane (when in dim light or darkness only), black tentacles</text>
+			<text>1/day each: bane (when in dim light or darkness only), Evard's black tentacles</text>
 		</trait>
 		<trait>
 			<name>Shadow Blend</name>
@@ -20678,7 +20678,7 @@ whirlwind by using its action to repeat the saving throw; on a success, it moves
 			<name>Innate Spellcasting</name>
 			<text>The voidling's innate spellcasting ability is Wisdom (spell save DC 15, spell attack bonus +7). It can innately cast the following spells, requiring no material components:</text>
 			<text>At will: darkness, detect magic, fear</text>
-			<text>3/day each: eldritch blast (3 beams), black tentacles</text>
+			<text>3/day each: eldritch blast (3 beams), Evard's black tentacles</text>
 			<text>1/day each: phantasmal force, reverse gravity</text>
 		</trait>
 		<trait>

--- a/Items/Guildmaster's Guide to Ravnica.xml
+++ b/Items/Guildmaster's Guide to Ravnica.xml
@@ -401,7 +401,7 @@
 		<text>1    blur</text>
 		<text>2    gust of wind</text>
 		<text>3    heat metal</text>
-		<text>4    Melfs acid arrow</text>
+		<text>4    Melf's acid arrow</text>
 		<text>5    scorching ray</text>
 		<text>6    shatter</text>
 		<text/>

--- a/fix_spells.py
+++ b/fix_spells.py
@@ -1,0 +1,98 @@
+"""Fix spells in Bestiary based on spells in Spells
+
+Run this file from the root directory (the place where this file resides)
+
+    $ python fix_spells.py
+
+This will update the XML files in the Bestiary directory.
+
+You can review optional parameters by invoking help
+
+    $ python fix_spells.py -h
+
+"""
+import argparse
+import os
+import re
+
+from difflib import unified_diff
+from glob import glob
+from xml.etree import ElementTree as et
+
+
+def find_spells(homebrew=False, verbose=False):
+    spell_sources = glob('Spells/*.xml')
+    if homebrew:
+        spell_sources += glob('Homebrew/Spells/*.xml')
+
+    if verbose:
+        # List files which will be used as source
+        print('Using these spell sources:\n  {}'.format('\n  '.join(spell_sources)))
+
+    spell_names = []
+
+    for spell_source in spell_sources:
+        root = et.parse(spell_source)
+
+        for spell_name in root.findall('./spell/name'):
+            spell_names.append(spell_name.text)
+
+    # Checks
+    if len(spell_names) != len(set(spell_name.casefold() for spell_name in spell_names)):
+        print('Duplicate spells were found!')
+
+    return set(spell_names)
+
+
+def fix_bestiary_spells(homebrew=False, verbose=False, dry_run=False):
+    spell_names = find_spells(homebrew=homebrew, verbose=verbose)
+
+    bestiary_sources = glob('Bestiary/*.xml')
+    if homebrew:
+        bestiary_sources += glob('Homebrew/Monsters/*.xml')
+
+    if verbose:
+        # List files which will be fixed
+        print('Fixing these bestiary sources:\n  {}'.format('\n  '.join(bestiary_sources)))
+
+    for bestiary_source in bestiary_sources:
+        with open(bestiary_source, mode='r') as bestiary_file:
+            bestiary_content = bestiary_file.read()
+        original_content = bestiary_content
+        for spell_name in spell_names:
+            bestiary_content = re.sub(
+                r'(<spells(>|.*, )){spell_name}((, .*|<)/spells>)'.format(spell_name=spell_name),
+                r'\1{spell_name}\3'.format(spell_name=spell_name),
+                bestiary_content,
+                flags=re.IGNORECASE
+            )
+
+        if verbose:
+            # Show diff for each fixed file
+            diff = ''.join(unified_diff(
+                original_content.splitlines(keepends=True),
+                bestiary_content.splitlines(keepends=True),
+                fromfile=bestiary_source,
+                tofile='fixed',
+                n=0
+            ))
+            if diff:
+                print(diff)
+
+        if not dry_run:
+            with open(bestiary_source, mode='w') as bestiary_file:
+                bestiary_file.write(bestiary_content)
+    if dry_run:
+        print('Dry run, did not write results back to files')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Fix spells in Bestiaries using the spell sources.',
+    )
+    parser.add_argument('--homebrew', action='store_true', help='Include homebrew spells and bestiary')
+    parser.add_argument('--verbose', action='store_true', help='Be more verbose while processing')
+    parser.add_argument('--dry-run', action='store_true', help='Do not write fixed content back to files')
+    args = parser.parse_args()
+
+    fix_bestiary_spells(homebrew=args.homebrew, verbose=args.verbose, dry_run=args.dry_run)


### PR DESCRIPTION
This adds a Python script to check and fix the capitalisation of spells in `<spells>` tags for monsters, by using the names of the spells in the Spells .xml files.

I have also executed the script to fix those that were currently wrong.

On my list for things to add in the future (later PR): Check if there are any spells in a monsters `<spells>` block that do not match any of the actual spells.