### PR TITLE
Changed weapons that use non BPS to use correct base dmg, resolves #386

### DIFF
--- a/Homebrew/Items/Strongholds and Followers.xml
+++ b/Homebrew/Items/Strongholds and Followers.xml
@@ -55,12 +55,19 @@
 		<name>Wound</name>
 		<type>M</type>
 		<magic>1</magic>
-		<weight/>
+		<weight>7</weight>
+		<dmg1>1d12</dmg1>
+		<dmgType>S</dmgType>
+		<property>H,2H</property>
 		<rarity>Rare</rarity>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a barbarian</text>
 		<text>The wicked edge of this serrated greataxe is permanently coated in dried blood.</text>
 		<text>	This greataxe has a +1 bonus to attack and damage rolls. Also, while you are raging, your attacks with this weapon deal an extra 2d6 necrotic damage, and the target’s maximum hit points are decreased in equal amount to the necrotic damage dealt. The target’s hit point maximum does not return to normal until it finishes a long rest or its grievous wounds are soothed by a greater restoration spell.</text>
+		<text />
+		<text>Heavy: Small creatures have disadvantage on attack rolls with heavy weapons. A heavy weapon's size and bulk make it too large for a Small creature to use effectively.</text>
+		<text/>
+		<text>Two-Handed: This weapon requires two hands to use.</text>
 		<roll>2d6</roll>
 		<modifier category="bonus">melee attacks +1</modifier>
 		<modifier category="bonus">melee damage +1</modifier>

--- a/Homebrew/Items/Tal'dorei Campaign Setting.xml
+++ b/Homebrew/Items/Tal'dorei Campaign Setting.xml
@@ -73,7 +73,7 @@
 		<value>50</value>
 		<range>30</range>
 		<dmg1>4d6</dmg1>
-		<dmgType/>
+		<dmgType>F</dmgType>
 		<magic/>
 		<weight/>
 		<rarity/>

--- a/Homebrew/Items/Xanathar's Lost Notes to Everything Else.xml
+++ b/Homebrew/Items/Xanathar's Lost Notes to Everything Else.xml
@@ -2186,7 +2186,7 @@
 		<text>Rarity: Very Rare</text>
 		<text>Requires Attunement</text>
 		<text>You gain a +1 bonus to attack and damage rolls with this magic weapon.</text>
-		<text>  When a wielder attuned to this longbow slays a creature with an arrow shot from it, the soul of the creature it killed is trapped within the mahogany, rune- scored bow. The creature killed in this manner can't be resurrected. As a bonus action, the wielder can transfer the soul trapped into the bow into an arrow is it is fired. Such an arrow attacks with advantage and does an extra 3d6 necrotic damage on a hit. Once a soul leaves the bow, another can't enter the bow for a full 24 hours.</text>
+		<text>  When a wielder attuned to this longbow slays a creature with an arrow shot from it, the soul of the creature it killed is trapped within the mahogany, rune-scored bow. The creature killed in this manner can't be resurrected. As a bonus action, the wielder can transfer the soul trapped into the bow into an arrow is it is fired. Such an arrow attacks with advantage and does an extra 3d6 necrotic damage on a hit. Once a soul leaves the bow, another can't enter the bow for a full 24 hours.</text>
 		<text>  If the wielder attuned to the longbow of lost souls dies while within 10 feet of the bow, the wielder's soul enters the bow instead. The wielder can't be returned to life until the bow is attuned to a new wielder, and then an arrow can be fired to release the soul.</text>
 	</item>
 	<item>

--- a/Items/Curse of Strahd.xml
+++ b/Items/Curse of Strahd.xml
@@ -115,7 +115,7 @@
 		<magic>1</magic>
 		<dmg1>1d8</dmg1>
 		<dmg2>1d10</dmg2>
-		<dmgType>S</dmgType>
+		<dmgType>R</dmgType>
 		<weight>3</weight>
 		<property>F,V</property>
 		<text>This item requires attunement</text>

--- a/Items/Dungeon Master's Guide.xml
+++ b/Items/Dungeon Master's Guide.xml
@@ -8467,7 +8467,7 @@
 		<weight>3</weight>
 		<dmg1>1d8</dmg1>
 		<dmg2>1d10</dmg2>
-		<dmgType>S</dmgType>
+		<dmgType>R</dmgType>
 		<property>F,V</property>
 		<rarity>Rare</rarity>
 		<text>Rarity: Rare</text>
@@ -10706,7 +10706,7 @@
 		<text>If you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean produces an effect 1 minute later from the ground where it was planted. The DM can choose an effect from the following table, determine it randomly, or create an effect.</text>
 		<text/>
 		<text>d100 — Effect: </text>
-		<text>01 — 5d4 toadstools sprout. If a creature eats a toadstool, roll any die. On an odd roll, the eater must succeed on a DC 15 Constitution saving throw or take Sd6 poison damage and become poisoned for 1 hour. On an even roll, the eater gains 5d6 temporary hit points for 1 hour.</text>
+		<text>01 — 5d4 toadstools sprout. If a creature eats a toadstool, roll any die. On an odd roll, the eater must succeed on a DC 15 Constitution saving throw or take 5d6 poison damage and become poisoned for 1 hour. On an even roll, the eater gains 5d6 temporary hit points for 1 hour.</text>
 		<text>2-10 — A geyser erupts and spouts water, beer, berry juice, tea, vinegar, wine, or oil (DM's choice) 30 feet into the air for 1d12 rounds.</text>
 		<text>11-20 — A treant sprouts (see the Monster Manual for statistics). There's a 50 percent chance that the treant is chaotic evil and attacks.</text>
 		<text>21-30 — An animate, immobile stone statue in your likeness rises. It makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows where you are. The statue becomes inanimate after 24 hours.</text>

--- a/Items/Dungeon of the Mad Mage.xml
+++ b/Items/Dungeon of the Mad Mage.xml
@@ -97,12 +97,12 @@
 		<weight/>
 		<rarity>Rare</rarity>
 		<text>Rarity: Rare</text>
-		<text>this twelve-sided metal die is 12 inches across and bears the numbers 1through12 engraved on its pentagonal sides. The dodecahedron contains arcane clockwork mecha- nisms that whir and click whenever the die is cast.</text>
-		<text>	The dodecahedron can be hurled up to 60 feet as an action. A random magical effect occurs when the die comes to rest after rolling across the ground for at least 10 feet. If an effect requires a target and no eligible tar- get is within range, nothing happens. Spells cast by the dodecahedron require no components. Roll a d12 and consult the following table to determine the effect:</text>
+		<text>this twelve-sided metal die is 12 inches across and bears the numbers 1 through 12 engraved on its pentagonal sides. The dodecahedron contains arcane clockwork mechanisms that whir and click whenever the die is cast.</text>
+		<text>	The dodecahedron can be hurled up to 60 feet as an action. A random magical effect occurs when the die comes to rest after rolling across the ground for at least 10 feet. If an effect requires a target and no eligible target is within range, nothing happens. Spells cast by the dodecahedron require no components. Roll a d12 and consult the following table to determine the effect:</text>
 		<text>d12    Effect</text>
 		<text>1-2    The dodecahedron explodes and is destroyed. Each creature within 20 feet of the exploding die must make a DC 13 Dexterity saving throw, taking 40 (9d8) force damage on a failed save, or half as much damage on a successful one.</text>
 		<text>3-4    The dodecahedron casts light on itself. The effect lasts until a creature touches the die.</text>
-		<text>5-6    The dodecahedron casts ray of frost (+S to hit), targeting a random creature within 60 feet of it that doesn't have total cover against the attack.</text>
+		<text>5-6    The dodecahedron casts ray of frost (+5 to hit), targeting a random creature within 60 feet of it that doesn't have total cover against the attack.</text>
 		<text>7-8    The dodecahedron casts shocking grasp (+5 to hit) on the next creature that touches it.</text>
 		<text>9-10   The dodecahedron casts darkness on itself. The effect has a duration of 10 minutes.</text>
 		<text>11-12  The next creature to touch the dodecahedron gains 1d10 temporary hit points that last for 1 hou r.</text>

--- a/Items/Eberron.xml
+++ b/Items/Eberron.xml
@@ -3427,19 +3427,6 @@
 		<roll>1d4</roll>
 	</item>
 	<item>
-		<name>Armblade of Fish Command(Trident)</name>
-		<type>M</type>
-		<magic>1</magic>
-		<weight>4</weight>
-		<dmg1>1d6</dmg1>
-		<dmgType>P</dmgType>
-		<property/>
-		<rarity>Uncommon</rarity>
-		<text>Rarity: Uncommon</text>
-		<text>	This trident is a magic weapon. It has 3 charges. While you carry it, you can use an action and expend 1 charge to cast dominate beast (save DC 15) from it on a beast that has an innate swimming speed. The trident regains 1d3 expended charges daily at dawn.</text>
-		<roll>1d3</roll>
-	</item>
-	<item>
 		<name>Vorpal Armblade(Longsword)</name>
 		<type>M</type>
 		<magic>1</magic>
@@ -3478,53 +3465,6 @@
 		<modifier category="bonus">melee attacks +3</modifier>
 		<modifier category="bonus">melee damage +3</modifier>
 		<roll>6d8</roll>
-	</item>
-	<item>
-		<name>Quaal's Feather Token, Armblade(Whip)</name>
-		<type>W</type>
-		<magic>1</magic>
-		<rarity>Rare</rarity>
-		<text>Rarity: Rare</text>
-		<text>This tiny object looks like a feather.</text>
-		<text/>
-		<text>Whip: You can use an action to throw the token to a point within 10 feet of you. The token disappears, and a floating whip takes its place. You can then use a bonus action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 force damage.</text>
-		<text>As a bonus action on your turn, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of it. The whip disappears after 1 hour, when you use an action to dismiss it, or when you are incapacitated or die.</text>
-		<roll>1d20+9</roll>
-		<roll>1d6+5</roll>
-	</item>
-	<item>
-		<name>Dragontooth Armblade(Dagger)</name>
-		<type>M</type>
-		<magic>1</magic>
-		<weight>1</weight>
-		<dmg1>1d4</dmg1>
-		<dmgType>P</dmgType>
-		<property>F,L</property>
-		<text>A dagger fashioned from the tooth of a dragon. While the blade is obviously a fang or predator's tooth, the handle is leather wrapped around the root of the tooth, and there is no crossguard.</text>
-		<text>You gain a +1 bonus to attack rolls and damage rolls you make with this weapon. On a hit with this weapon, the target takes an extra 1d6 acid damage.</text>
-		<text>Draconic Potency: Against enemies of the Cult of the Dragon, the dagger's bonus to attack rolls and damage rolls increases to 2, and the extra acid damage increases to 2d6.</text>
-		<text/>
-		<text>Finesse: When making an attack with a finesse weapon, you use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls.</text>
-		<text/>
-		<text>Light: A light weapon is small and easy to handle, making it ideal for use when fighting with two weapons.</text>
-		<text/>
-		<text/>
-		<modifier category="bonus">weapon attacks +1</modifier>
-		<modifier category="bonus">weapon damage +1</modifier>
-		<roll>1d6</roll>
-	</item>
-	<item>
-		<name>Blood Armblade(Spear)</name>
-		<type>M</type>
-		<magic>1</magic>
-		<dmg1>1d6</dmg1>
-		<dmgType>P</dmgType>
-		<weight>3</weight>
-		<property/>
-		<text>This item requires attunement</text>
-		<text/>
-		<text>Kavan was a ruthless chieftain whose tribe lived in the Balinok Mountains centuries before the arrival of Strahd von Zarovich. Although he was very much alive, Kavan had some traits in common with vampires: he slept during the day and hunted at night, he drank the blood of his prey, and he lived underground. In battle, he wielded a spear stained with blood. His was the first blood spear, a weapon that drains life from those it kills and transfers that life to its wielder, imbuing that individual with the stamina to keep fighting.</text>
-		<text>	When you hit with a melee attack using this magic spear and reduce the target to 0 hit points, you gain 2d6 temporary hit points.</text>
 	</item>
 	<item>
 		<name>Mind Blade Armblade(Longsword)</name>

--- a/Items/Guildmaster's Guide to Ravnica.xml
+++ b/Items/Guildmaster's Guide to Ravnica.xml
@@ -590,8 +590,8 @@
 		<text>Rarity: Rare</text>
 		<text>This short tube, about 2 feet long and 6 inches in diameter, is made from mizzium, a magically enhanced metal alloy forged by the Izzet League. The end that's pointed toward a target is open, and a glowing ball of molten metal can be seen at the other end as long as the mortar has at least 1 charge remaining.</text>
 		<text>	The mortar has 4 charges for the following properties. It regains 1d4 expended charges daily at dawn.</text>
-		<text>	Molten Spray. You can expend 1 charge as an action to loose a 30-foot cone of molten mizzium. Each creature in the area must make a DC 15 Dexterity saving throw, taking Sd4 fire damage on a failed save, or half as much damage on a successful one.</text>
-		<text>	Mizzium Bombard. You can expend 3 charges as an action to launch a hail of molten projectiles in a 20-foot-radius. 40-foot-high cylinder centered on a point you can see within 60 feet of you. Each creature in the area must make a DC 15 Dexterity saving throw. A creature takes Sd8 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<text>	Molten Spray. You can expend 1 charge as an action to loose a 30-foot cone of molten mizzium. Each creature in the area must make a DC 15 Dexterity saving throw, taking 5d4 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<text>	Mizzium Bombard. You can expend 3 charges as an action to launch a hail of molten projectiles in a 20-foot-radius. 40-foot-high cylinder centered on a point you can see within 60 feet of you. Each creature in the area must make a DC 15 Dexterity saving throw. A creature takes 5d8 fire damage on a failed save, or half as much damage on a successful one.</text>
 	</item>
 	<item>
 		<name>Moodmark Paint</name>
@@ -615,7 +615,7 @@
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement</text>
 		<text>Soldiers of the Boros Legion consider it an honor to bear this shield, even knowing that it might be the last honor they receive. The front of the shield is sculpted to depict a grieving human face.</text>
-		<text>	You gain a +l bonus to AC for every two allies within 5 feet of you (up to a maximum of +3) while you wield this shield. This bonus is in addition to the shield's normal bonus to AC.</text>
+		<text>	You gain a +1 bonus to AC for every two allies within 5 feet of you (up to a maximum of +3) while you wield this shield. This bonus is in addition to the shield's normal bonus to AC.</text>
 		<text>	When a creature you can see within 5 feet of you takes damage, you can use your reaction to take that damage, instead of the creature taking it. When you do so, the damage type changes to force.</text>
 	</item>
 	<item>
@@ -660,7 +660,7 @@
 		<text>You gain a +1 bonus to attack and damage rolls made with this magic weapon. Its blade is cruelly serrated, and its hilt resembles a demonic head and wings. Whenever you slay a creature with an attack using the dagger, the creature's soul is imprisoned inside the dagger, and that creature can be restored to life only by a wish spell. The dagger can hold a maximum of five souls.</text>
 		<text>	For each soul imprisoned in the dagger, your attacks with it deal an extra 1d4 necrotic damage on a hit. While the dagger is within 5 feet of you, your dreams are haunted by whispers from the trapped souls.</text>
 		<text>	The dagger has the following additional properties.</text>
-		<text>	Siphon Vitality. As a bonus action, you can release any number of stored souls from the dagger to regain 1d1O hit points per soul released.</text>
+		<text>	Siphon Vitality. As a bonus action, you can release any number of stored souls from the dagger to regain 1d10 hit points per soul released.</text>
 		<text>	Annihilation. If the dagger holds five souls, you can use this property: As a reaction immediately after you hit a creature with the dagger and deal damage to that target, you can release all five souls. If the target now has fewer than 75 hit points, it must succeed on a DC 15 Constitution saving throw or die. If the target dies, you can't use this property again until you finish a long rest.</text>
 		<modifier category="bonus">melee attacks +1</modifier>
 		<modifier category="bonus">melee damage +1</modifier>

--- a/Items/Out of the Abyss.xml
+++ b/Items/Out of the Abyss.xml
@@ -8,7 +8,7 @@
 		<weight>3</weight>
 		<dmg1>1d8</dmg1>
 		<dmg2>1d10</dmg2>
-		<dmgType>S</dmgType>
+		<dmgType>R</dmgType>
 		<property>F,V</property>
 		<text>Requires attunement by a creature of non-evil alignment</text>
 		<text/>


### PR DESCRIPTION
There aren't actually a lot of places that these types can be used, since the app only tracks the main damage type, i.e., 2d6 Piercing, regardless of whether the weapon can do an additional 1d6 Fire