### PR TITLE
Fixed several compendium compilation errors and some more QOL

### DIFF
--- a/Character/Backgrounds/Guildmaster's Guide to Ravnica.xml
+++ b/Character/Backgrounds/Guildmaster's Guide to Ravnica.xml
@@ -22,7 +22,7 @@
 			<text>You have the authority to enforce the laws of Ravnica, and that status inspires a certain amount of respect and even fear in the populace. People mind their manners in your presence and avoid drawing your attention; they assume you have the right to be wherever you are. Showing your Azorius insignia gets you an audience with anyone you want to talk to (though it might cause more problems than it solves when you're dealing with incorrigible lawbreakers). If you abuse this privilege, though, you can get in serious trouble with your superiors and even be stripped of your position.</text>
 		</trait>
 	</background>
-	<spellList class="Azorius Guild">
+	<spellList class="Guild Azorius">
 		<index name="Friends"/>
 		<index name="Message"/>
 		<index name="Command"/>
@@ -57,7 +57,7 @@
 			<text>You have an established place in the hierarchy of the Boros Legion. You can requisition simple equipment for temporary use, and you can gain access to any Boros garrison in Ravnica, where you can rest in safety and receive the attention of medics. You are also paid a salary of 1 gp (a Boros-minted 1-zino coin) per week, which (combined with free lodging in your garrison) enables you to maintain a poor lifestyle between adventures.</text>
 		</trait>
 	</background>
-	<spellList class="Boros Guild">
+	<spellList class="Guild Boros">
 		<index name="Fire Bolt"/>
 		<index name="Sacred Flame"/>
 		<index name="Guiding Bolt"/>
@@ -103,7 +103,7 @@
 			<text>8   I chose this guild at random or on a lark.</text>
 		</trait>
 	</background>
-	<spellList class="Dimir Guild">
+	<spellList class="Guild Dimir">
 		<index name="Encode Thoughts"/>
 		<index name="Mage Hand"/>
 		<index name="Disguise Self"/>
@@ -138,7 +138,7 @@
 			<text>You know hidden, underground pathways that you can use to bypass crowds, obstacles, and observation as you move through the city. When you aren't in combat, you and companions you lead can travel between any two lo- cations in the city twice as fast as your speed would normally allow. The paths of the undercity are haunted by dangers that rarely brave the light of the surface world, so your journey isn't guaranteed to be safe.</text>
 		</trait>
 	</background>
-	<spellList class="Golgari Guild">
+	<spellList class="Guild Golgari">
 		<index name="Dancing Lights"/>
 		<index name="Spare the Dying"/>
 		<index name="Entangle"/>
@@ -174,7 +174,7 @@
 			<text>You are intimately familiar with areas of the city that most people shun: ruined neighborhoods where wurms rampaged, overgrown parks that no hand has tended in decades, and the vast. sprawling rubblebelts of broken terrain that civilized folk have long abandoned. You can find a suitable place for you and your allies to hide or rest in these areas. In addition, you can find food and fresh water in these areas for yourself and up to five other people each day.</text>
 		</trait>
 	</background>
-	<spellList class="Gruul Guild">
+	<spellList class="Guild Gruul">
 		<index name="Fire Bolt"/>
 		<index name="Produce Flame"/>
 		<index name="Compelled Duel"/>
@@ -210,7 +210,7 @@
 			<text>	You have a basic knowledge of the structure of buildings, including the stuff behind the walls. You can also find blueprints of a specific building in order to learn the details of its construction. Such blueprints might provide knowledge of entry points, structural weaknesses, or secret spaces. Your access to such information isn't unlimited. If obtaining or using the information gets you in trouble with the law, the guild can't shield you from the repercussions.</text>
 		</trait>
 	</background>
-	<spellList class="Izzet Guild">
+	<spellList class="Guild Izzet">
 		<index name="Produce Flame"/>
 		<index name="Shocking Grasp"/>
 		<index name="Chaos Bolt"/>
@@ -244,7 +244,7 @@
 			<text>You can exert leverage over one or more individuals below you in the guild's hierarchy and demand their help as needs warrant. For example, you can have a message carried across a neighborhood, procure a short carriage ride without paying, or have others clean up a bloody mess you left in an alley. The DM decides if your demands are reasonable and if there are subordinates available to fulfill them. As your status in the guild improves, you gain influence over more people, including ones in greater positions of power.</text>
 		</trait>
 	</background>
-	<spellList class="Orzhov Guild">
+	<spellList class="Guild Orzhov">
 		<index name="Friends"/>
 		<index name="Guidance"/>
 		<index name="Command"/>
@@ -281,7 +281,7 @@
 			<text>People recognize you as a member of the Cult of Rakdos, and they're careful not to draw your anger or ridicule. You can get away with minor criminal offenses, such as refusing to pay for food at a restaurant or breaking down a door at a local shop, if no legal authorities witness the crime. Most people are too daunted by you to report your wrongdoing to the Azorius.</text>
 		</trait>
 	</background>
-	<spellList class="Rakdos Guild">
+	<spellList class="Guild Rakdos">
 		<index name="Fire Bolt"/>
 		<index name="Vicious Mockery"/>
 		<index name="Burning Hands"/>
@@ -317,7 +317,7 @@
 			<text>	In addition, as a guild member you can receive free healing and care at a Selesnya enclave, though you must provide any material components needed for spells.</text>
 		</trait>
 	</background>
-	<spellList class="Selesnya Guild">
+	<spellList class="Guild Selesnya">
 		<index name="Druidcraft"/>
 		<index name="Friends"/>
 		<index name="Aid"/>
@@ -351,7 +351,7 @@
 			<text>	Your DM might rule that the knowledge you seek is secreted away in an inaccessible place, or that it simply can't be found. Unearthing the deepest secrets of the multiverse can require an adventure or even a whole campaign.</text>
 		</trait>
 	</background>
-	<spellList class="Simic Guild">
+	<spellList class="Guild Simic">
 		<index name="Acid Splash"/>
 		<index name="Druidcraft"/>
 		<index name="Detect Poison and Disease"/>

--- a/Character/Classes/Mystic/Mystic (Avatar).xml
+++ b/Character/Classes/Mystic/Mystic (Avatar).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Avatar)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Awakened).xml
+++ b/Character/Classes/Mystic/Mystic (Awakened).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Awakened)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Immortal).xml
+++ b/Character/Classes/Mystic/Mystic (Immortal).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Immortal)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Nomad).xml
+++ b/Character/Classes/Mystic/Mystic (Nomad).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Nomad)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Soul Knife).xml
+++ b/Character/Classes/Mystic/Mystic (Soul Knife).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Soul Knife)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Wu Jen).xml
+++ b/Character/Classes/Mystic/Mystic (Wu Jen).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Wu Jen)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic.xml
+++ b/Character/Classes/Mystic/Mystic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<baseclass UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<baseclass>
 		<name>Mystic (UA)</name>
 		<hd>8</hd>
 		<proficiency>Intelligence, Wisdom, Arcana, History, Insight, Medicine, Nature, Perception, Religion</proficiency>

--- a/Character/Classes/Sorcerer/Sorcerer.xml
+++ b/Character/Classes/Sorcerer/Sorcerer.xml
@@ -156,12 +156,12 @@
 			<feature optional="YES">
 				<name>Metamagic: Distant Spell</name>
 				<text>When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell.</text>
-				<text>When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
+				<text> When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Empowered Spell</name>
 				<text>When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls.</text>
-				<text>You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
+				<text> You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Extended Spell</name>
@@ -181,7 +181,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Twinned Spell</name>
-				<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+				<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
 		<autolevel level="4" scoreImprovement="YES">
@@ -228,7 +228,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Twinned Spell</name>
-				<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+				<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
 		<autolevel level="12" scoreImprovement="YES">
@@ -277,7 +277,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Twinned Spell</name>
-				<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+				<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
 		<autolevel level="18">
@@ -303,14 +303,14 @@
 		<classes>Sorcerer Metamagic</classes>
 		<level>1</level>
 		<text>When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell.</text>
-		<text>When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
+		<text> When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
 	</spell>
 	<spell PS="PS">
 		<name>Metamagic: Empowered Spell</name>
 		<classes>Sorcerer Metamagic</classes>
 		<level>1</level>
 		<text>When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls.</text>
-		<text>You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
+		<text> You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
 	</spell>
 	<spell PS="PS">
 		<name>Metamagic: Extended Spell</name>
@@ -340,6 +340,6 @@
 		<name>Metamagic: Twinned Spell</name>
 		<classes>Sorcerer Metamagic</classes>
 		<level>1</level>
-		<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+		<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 	</spell>
 </compendium>

--- a/Character/Classes/Sorcerer/Sorcerer.xml
+++ b/Character/Classes/Sorcerer/Sorcerer.xml
@@ -147,6 +147,8 @@
 				<text>At 3rd level, you gain the ability to twist your spells to suit your needs. You gain two of the following Metamagic options of your choice. You gain another one at 10th and 17th level.</text>
 				<text>	You can use only one Metamagic option on a spell when you cast it, unless otherwise noted.</text>
 			</feature>
+		</autolevel>
+		<autolevel level="3" IL="IL">
 			<feature optional="YES">
 				<name>Metamagic: Careful Spell</name>
 				<text>When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell's full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell.</text>
@@ -154,12 +156,12 @@
 			<feature optional="YES">
 				<name>Metamagic: Distant Spell</name>
 				<text>When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell.</text>
-				<text>	When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
+				<text>When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Empowered Spell</name>
 				<text>When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls.</text>
-				<text>	You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
+				<text>You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Extended Spell</name>
@@ -189,7 +191,7 @@
 		</autolevel>
 		<autolevel level="8" scoreImprovement="YES">
 		</autolevel>
-		<autolevel level="10">
+		<autolevel level="10" IL="IL">
 			<feature>
 				<name>Metamagic Option (3rd)</name>
 				<text>At 10th level, you learn an additional metamagic option.</text>
@@ -226,7 +228,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Twinned Spell</name>
-				<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+				<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
 		<autolevel level="12" scoreImprovement="YES">
@@ -241,6 +243,8 @@
 				<name>Metamagic Option (4th)</name>
 				<text>At 17th level, you learn an additional metamagic option.</text>
 			</feature>
+		</autolevel>
+		<autolevel level="17" IL="IL">
 			<feature optional="YES">
 				<name>Metamagic: Careful Spell</name>
 				<text>When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell's full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell.</text>
@@ -273,7 +277,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Twinned Spell</name>
-				<text>When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+				<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
 			</feature>
 		</autolevel>
 		<autolevel level="18">
@@ -288,4 +292,54 @@
 			</feature>
 		</autolevel>
 	</baseclass>
+	<spell PS="PS">
+		<name>Metamagic: Careful Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell's full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Distant Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell.</text>
+		<text>When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Empowered Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls.</text>
+		<text>You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Extended Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell that has a duration of 1 minute or longer, you can spend 1 sorcery point to double its duration, to a maximum duration of 24 hours.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Heightened Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell that forces a creature to make a saving throw to resist its effects, you can spend 3 sorcery points to give one target of the spell disadvantage on its first saving throw made against the spell.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Quickened Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell that has a casting time of 1 action, you can spend 2 sorcery points to change the casting time to 1 bonus action for this casting.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Subtle Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell, you can spend 1 sorcery point to cast it without any somatic or verbal components.</text>
+	</spell>
+	<spell PS="PS">
+		<name>Metamagic: Twinned Spell</name>
+		<classes>Sorcerer Metamagic</classes>
+		<level>1</level>
+		<text>When you cast a spell that doesn't have a range of self and is incapable of targeting more than one creature at the spell's current level, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).</text>
+	</spell>
 </compendium>

--- a/Character/Classes/Sorcerer/Sorcerer.xml
+++ b/Character/Classes/Sorcerer/Sorcerer.xml
@@ -156,12 +156,12 @@
 			<feature optional="YES">
 				<name>Metamagic: Distant Spell</name>
 				<text>When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell.</text>
-				<text> When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
+				<text>	When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Empowered Spell</name>
 				<text>When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls.</text>
-				<text> You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
+				<text>	You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Metamagic: Extended Spell</name>
@@ -303,14 +303,14 @@
 		<classes>Sorcerer Metamagic</classes>
 		<level>1</level>
 		<text>When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell.</text>
-		<text> When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
+		<text>	When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet.</text>
 	</spell>
 	<spell PS="PS">
 		<name>Metamagic: Empowered Spell</name>
 		<classes>Sorcerer Metamagic</classes>
 		<level>1</level>
 		<text>When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls.</text>
-		<text> You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
+		<text>	You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell.</text>
 	</spell>
 	<spell PS="PS">
 		<name>Metamagic: Extended Spell</name>

--- a/Character/Classes/Warlock/Warlock.xml
+++ b/Character/Classes/Warlock/Warlock.xml
@@ -235,7 +235,7 @@
 			</feature>
 		</autolevel>
 		<!-- Repeated Eldritch Invocation -->
-		<autolevel level="2">
+		<autolevel level="2" IL="IL">
 			<feature optional="YES">
 				<name>Eldritch Invocation: Agonizing Blast</name>
 				<text>Prerequisite: eldritch blast cantrip</text>
@@ -344,7 +344,7 @@
 				<text>You can communicate telepathically with your familiar and perceive through your familiar's senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="5">
+		<autolevel level="5" IL="IL">
 			<!-- Newly available Invocations (level prerequisite)-->
 			<feature optional="YES">
 				<name>Eldritch Invocation: Cloak of Flies</name>
@@ -522,7 +522,7 @@
 				<text>You can communicate telepathically with your familiar and perceive through your familiar's senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="7">
+		<autolevel level="7" IL="IL">
 			<!-- Newly available Invocations (level prerequisite)-->
 			<feature optional="YES">
 				<name>Eldritch Invocation: Bewitching Whispers</name>
@@ -731,7 +731,7 @@
 				<text>You can communicate telepathically with your familiar and perceive through your familiar's senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="9">
+		<autolevel level="9" IL="IL">
 			<!-- Newly available Invocations (level prerequisite)-->
 			<feature optional="YES">
 				<name>Eldritch Invocation: Ascendant Step</name>
@@ -964,7 +964,7 @@
 				<text>You can communicate telepathically with your familiar and perceive through your familiar's senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="12">
+		<autolevel level="12" IL="IL">
 			<!-- Newly available Invocations (level prerequisite)-->
 			<feature optional="YES">
 				<name>Eldritch Invocation: Lifedrinker</name>
@@ -1203,7 +1203,7 @@
 				<text>You can cast speak with dead at will, without expending a spell slot.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="15">
+		<autolevel level="15" IL="IL">
 			<!-- Newly available Invocations (level prerequisite)-->
 			<feature optional="YES">
 				<name>Eldritch Invocation: Chains of Carceri</name>
@@ -1472,7 +1472,7 @@
 				<text>You can cast speak with dead at will, without expending a spell slot.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="18">
+		<autolevel level="18" IL="IL">
 			<!-- Newly available Invocations (level prerequisite)-->
 		</autolevel>
 		<autolevel level="18" IL="IL">
@@ -1742,7 +1742,7 @@
 			</feature>
 		</autolevel>
 		<!-- Unearthed Arcana Eldritch Invocations-->
-		<autolevel level="2">
+		<autolevel level="2" IL="IL">
 			<feature UA="Revised Class Options" optional="YES">
 				<name>Eldritch Invocation: Frost Lance (UA)</name>
 				<text>Prerequisite: eldritch blast cantrip</text>
@@ -1752,7 +1752,7 @@
 				<text>This Eldritch Invocation is from Unearthed Arcana: Revised Class Options, and as such may not be allowed in your game. Consult your DM before choosing this option.</text>
 			</feature>
 		</autolevel>
-		<autolevel level="5">
+		<autolevel level="5" IL="IL">
 			<feature UA="Revised Class Options" optional="YES">
 				<name>Eldritch Invocation: Kiss of Mephistopheles (UA)</name>
 				<text>Prerequisite: 5th level, eldritch blast cantrip</text>
@@ -1763,7 +1763,7 @@
 			</feature>
 		</autolevel>
 		<!-- Eldritch Invocations from Warlock & Wizard not repeated/replaced in Revised Class Options-->
-		<autolevel level="2">
+		<autolevel level="2" IL="IL">
 			<feature UA="Warlock &amp; Wizard" optional="YES">
 				<name>Eldritch Invocation: Caiphon's Beacon (UA)</name>
 				<text>Prerequisite: The Great Old One patron</text>

--- a/Homebrew/Classes/Barbarian/Barbarian (Courageous Heart).xml
+++ b/Homebrew/Classes/Barbarian/Barbarian (Courageous Heart).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Barbarian" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Barbarian">
 		<name>Barbarian (Courageous Heart)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Barbarian/Barbarian (Harrier).xml
+++ b/Homebrew/Classes/Barbarian/Barbarian (Harrier).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Barbarian" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Barbarian">
 		<name>Barbarian (Harrier)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Barbarian/Barbarian (Juggernaut).xml
+++ b/Homebrew/Classes/Barbarian/Barbarian (Juggernaut).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Barbarian" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Barbarian">
 		<name>Barbarian (Juggernaut)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Barbarian/Barbarian (Legendary Wrestler).xml
+++ b/Homebrew/Classes/Barbarian/Barbarian (Legendary Wrestler).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Barbarian" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Barbarian">
 		<name>Barbarian (Legendary Wrestler)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Barbarian/Barbarian (Red Reaver).xml
+++ b/Homebrew/Classes/Barbarian/Barbarian (Red Reaver).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Barbarian" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Barbarian">
 		<name>Barbarian (Red Reaver)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Bard/Bard (Discord).xml
+++ b/Homebrew/Classes/Bard/Bard (Discord).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Bard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Bard">
 		<name>Bard (Discord)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Bard/Bard (Keys).xml
+++ b/Homebrew/Classes/Bard/Bard (Keys).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Bard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Bard">
 		<name>Bard (Keys)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Bard/Bard (Maestro).xml
+++ b/Homebrew/Classes/Bard/Bard (Maestro).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Bard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Bard">
 		<name>Bard (Maestro)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Bard/Bard (Mourning).xml
+++ b/Homebrew/Classes/Bard/Bard (Mourning).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Bard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Bard">
 		<name>Bard (Mourning)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Bard/Bard (Virtue).xml
+++ b/Homebrew/Classes/Bard/Bard (Virtue).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Bard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Bard">
 		<name>Bard (Virtue)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Blood Hunter/Blood Hunter (Ghostslayer).xml
+++ b/Homebrew/Classes/Blood Hunter/Blood Hunter (Ghostslayer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Blood Hunter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Blood Hunter">
 		<name>Blood Hunter (Ghostslayer)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Blood Hunter/Blood Hunter (Lychan).xml
+++ b/Homebrew/Classes/Blood Hunter/Blood Hunter (Lychan).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Blood Hunter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Blood Hunter">
 		<name>Blood Hunter (Lychan)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Blood Hunter/Blood Hunter (Mutant).xml
+++ b/Homebrew/Classes/Blood Hunter/Blood Hunter (Mutant).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Blood Hunter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Blood Hunter">
 		<name>Blood Hunter (Mutant)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Cleric/Cleric (Air).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Air).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Air)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Balance).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Balance).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Balance)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Beauty).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Beauty).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Beauty)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Blood).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Blood).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Blood)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Corruption).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Corruption).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Corruption)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Creation).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Creation).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Creation)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Earth).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Earth).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Earth)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Entropy).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Entropy).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Entropy)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Fire).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Fire).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Fire)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Madness).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Madness).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Madness)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Repose).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Repose).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Repose)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Survival).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Survival).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Survival)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Travel).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Travel).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Travel)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Tyranny).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Tyranny).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Tyranny)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Water).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Water).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Water)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Druid/Druid (Seasons).xml
+++ b/Homebrew/Classes/Druid/Druid (Seasons).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Druid" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Druid">
 		<name>Druid (Seasons)</name>
 		<autolevel level="2">
 			<feature optional="YES">

--- a/Homebrew/Classes/Druid/Druid (Spiritlords).xml
+++ b/Homebrew/Classes/Druid/Druid (Spiritlords).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Druid" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Druid">
 		<name>Druid (Spiritlords)</name>
 		<autolevel level="2">
 			<feature optional="YES">

--- a/Homebrew/Classes/Fighter/Fighter (Dragoon).xml
+++ b/Homebrew/Classes/Fighter/Fighter (Dragoon).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Fighter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Fighter">
 		<name>Fighter (Dragoon)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Fighter/Fighter (Gunslinger).xml
+++ b/Homebrew/Classes/Fighter/Fighter (Gunslinger).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Fighter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Fighter">
 		<name>Fighter (Gunslinger)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Fighter/Fighter (Runeguard).xml
+++ b/Homebrew/Classes/Fighter/Fighter (Runeguard).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Fighter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Fighter">
 		<name>Fighter (Runeguard)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Lingering Soul/Lingering Soul (Poltergeist).xml
+++ b/Homebrew/Classes/Lingering Soul/Lingering Soul (Poltergeist).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Lingering Soul" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Lingering Soul">
 		<name>Lingering Soul (Poltergeist)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Lingering Soul/Lingering Soul (Spirit Guardian).xml
+++ b/Homebrew/Classes/Lingering Soul/Lingering Soul (Spirit Guardian).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Lingering Soul" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Lingering Soul">
 		<name>Lingering Soul (Spirit Guardian)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Lingering Soul/Lingering Soul (Wraith).xml
+++ b/Homebrew/Classes/Lingering Soul/Lingering Soul (Wraith).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Lingering Soul" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Lingering Soul">
 		<name>Lingering Soul (Wraith)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Lingering Soul/Lingering Soul.xml
+++ b/Homebrew/Classes/Lingering Soul/Lingering Soul.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<baseclass name="Lingering Soul" HB="HB">
+<compendium version="5" HB="HB">
+	<baseclass name="Lingering Soul">
 		<name>Lingering Soul</name>
 		<hd>6</hd>
 		<proficiency>Constitution, History, Investigation, Insight, Intimidation, Perception, Religion, Sleight of Hand, Stealth</proficiency>

--- a/Homebrew/Classes/Mist Walker/Mist Walker (Blade).xml
+++ b/Homebrew/Classes/Mist Walker/Mist Walker (Blade).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mist Walker" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Mist Walker">
 		<name>Mist Walker (Blade)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Mist Walker/Mist Walker (Mind).xml
+++ b/Homebrew/Classes/Mist Walker/Mist Walker (Mind).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mist Walker" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Mist Walker">
 		<name>Mist Walker (Mind)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Mist Walker/Mist Walker (Shroud).xml
+++ b/Homebrew/Classes/Mist Walker/Mist Walker (Shroud).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mist Walker" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Mist Walker">
 		<name>Mist Walker (Shroud)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Mist Walker/Mist Walker.xml
+++ b/Homebrew/Classes/Mist Walker/Mist Walker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<baseclass name="Mist Walker" HB="HB">
+<compendium version="5" HB="HB">
+	<baseclass name="Mist Walker">
 		<name>Mist Walker</name>
 		<hd>10</hd>
 		<proficiency>Dexterity, Intelligence, Acrobatics, Deception, History, Intimidation, Investigation, Perception, Persuasion, Sleight of Hand, Stealth</proficiency>

--- a/Homebrew/Classes/Monk/Monk (Atonement).xml
+++ b/Homebrew/Classes/Monk/Monk (Atonement).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Monk" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Monk">
 		<name>Monk (Atonement)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Monk/Monk (Cobalt Soul).xml
+++ b/Homebrew/Classes/Monk/Monk (Cobalt Soul).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Monk" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Monk">
 		<name>Monk (Cobalt Soul)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Monk/Monk (Empathy).xml
+++ b/Homebrew/Classes/Monk/Monk (Empathy).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Monk" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Monk">
 		<name>Monk (Empathy)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Monk/Monk (Iron).xml
+++ b/Homebrew/Classes/Monk/Monk (Iron).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Monk" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Monk">
 		<name>Monk (Iron)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Ascetic).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Ascetic).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Ascetic)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Battle).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Battle).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Battle)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Eagle).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Eagle).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Eagle)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Mercy).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Mercy).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Mercy)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Perfection).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Perfection).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Perfection)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Predation).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Predation).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Predation)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Providence).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Providence).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Providence)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Ranger/Ranger (Burghal Explorer).xml
+++ b/Homebrew/Classes/Ranger/Ranger (Burghal Explorer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Ranger" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Ranger">
 		<name>Ranger (Burghal Explorer)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Ranger/Ranger (Wasteland Wanderer).xml
+++ b/Homebrew/Classes/Ranger/Ranger (Wasteland Wanderer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Ranger" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Ranger">
 		<name>Ranger (Wasteland Wanderer)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Rogue/Rogue (Scout).xml
+++ b/Homebrew/Classes/Rogue/Rogue (Scout).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Rogue" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Rogue">
 		<name>Rogue (Scout BotR)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Sorcerer/Sorcerer (Divine Inspiration).xml
+++ b/Homebrew/Classes/Sorcerer/Sorcerer (Divine Inspiration).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Sorcerer" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Sorcerer">
 		<name>Sorcerer (Divine Inspiration)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Sorcerer/Sorcerer (Fey Magic).xml
+++ b/Homebrew/Classes/Sorcerer/Sorcerer (Fey Magic).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Sorcerer" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Sorcerer">
 		<name>Sorcerer (Fey Magic)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Sorcerer/Sorcerer (Pyromancer).xml
+++ b/Homebrew/Classes/Sorcerer/Sorcerer (Pyromancer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Sorcerer" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Sorcerer">
 		<name>Sorcerer (Pyromancer)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Sorcerer/Sorcerer (Runechild).xml
+++ b/Homebrew/Classes/Sorcerer/Sorcerer (Runechild).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Sorcerer" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Sorcerer">
 		<name>Sorcerer (Runechild)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Sorcerer/Sorcerer (Spell Surge).xml
+++ b/Homebrew/Classes/Sorcerer/Sorcerer (Spell Surge).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Sorcerer" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Sorcerer">
 		<name>Sorcerer (Spell Surge)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Warlock/Warlock (Genie).xml
+++ b/Homebrew/Classes/Warlock/Warlock (Genie).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Warlock" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Warlock">
 		<name>Warlock (Genie)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Warlock/Warlock (Oracle).xml
+++ b/Homebrew/Classes/Warlock/Warlock (Oracle).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Warlock" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Warlock">
 		<name>Warlock (Oracle)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Warlock/Warlock (The Chaos).xml
+++ b/Homebrew/Classes/Warlock/Warlock (The Chaos).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Warlock" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Warlock">
 		<name>Warlock (The Chaos)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Wizard/Wizard (Artifice).xml
+++ b/Homebrew/Classes/Wizard/Wizard (Artifice).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Wizard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Wizard">
 		<name>Wizard (Artifice)</name>
 		<autolevel level="2">
 			<feature optional="YES">

--- a/Homebrew/Classes/Wizard/Wizard (Beguiler).xml
+++ b/Homebrew/Classes/Wizard/Wizard (Beguiler).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Wizard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Wizard">
 		<name>Wizard (Beguiler)</name>
 		<autolevel level="2">
 			<feature optional="YES">

--- a/Homebrew/Classes/Wizard/Wizard (Mage Hunter).xml
+++ b/Homebrew/Classes/Wizard/Wizard (Mage Hunter).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Wizard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Wizard">
 		<name>Wizard (Mage Hunter)</name>
 		<autolevel level="2">
 			<feature optional="YES">

--- a/Homebrew/Classes/Wizard/Wizard (Reconstruction).xml
+++ b/Homebrew/Classes/Wizard/Wizard (Reconstruction).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Wizard" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Wizard">
 		<name>Wizard (Reconstruction)</name>
 		<autolevel level="2">
 			<feature optional="YES">

--- a/Homebrew/Spells/Book of the Righteous.xml
+++ b/Homebrew/Spells/Book of the Righteous.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<spell>
 		<name>Anwyn's Elysian Palace</name>
 		<level>9</level>

--- a/Spells/Guildmaster's Guide to Ravnica.xml
+++ b/Spells/Guildmaster's Guide to Ravnica.xml
@@ -8,7 +8,7 @@
 		<range>Self</range>
 		<components>S</components>
 		<duration>Up to 8 hours</duration>
-		<classes>Dimir Guild</classes>
+		<classes>Guild Dimir</classes>
 		<text>Putting a finger to your head, you pull a memory, an idea, or a message from your mind and transform it into a tangible string of glowing energy called a thought strand, which persists for the duration or until you cast this spell again. The thought strand appears in an unoccupied space within 5 feet of you as a Tiny, weightless, semisolid object that can be held and carried like a ribbon. It is otherwise stationary.</text>
 		<text>	If you cast this spell while concentrating on a spell or an ability that allows you to read or manipulate the thoughts of others (such as detect thoughts or modify memory), you can transform the thoughts or memories you read, rather than your own, into a thought strand.</text>
 		<text>	Casting this spell while holding a thought strand allows you to instantly receive whatever memory, idea, or message the thought strand contains. (Casting detect thoughts on the strand has the same effect.)</text>

--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -175,6 +175,7 @@ class XMLCombiner(object):
                         continue
                     if c_name not in items['baseclass']:
                         print('Missing baseclass {0} for {1}'.format(c_name, name))
+                        continue
 
                     complete_class = items['class'][c_name]
                     complete_class.extend(list(element))


### PR DESCRIPTION
Commit log pretty much describes the changes. Aside from fixing a broken script that was putting each subclass info into every unique class object (option `-s usable`), I also (re)marked homebrew content and mystic class so that exclude option would actually exclude all of the content. Especially there was a problem with those spells, spell lists and pseudospells.
Also fixed Warlock's invocations not being marked as inlined list, and made Metamagic same kind of option (inlined list/pseudospell).