### PR TITLE
Allow windows path separators

### DIFF
--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -177,6 +177,7 @@ class XMLCombiner(object):
                         continue
                     if c_name not in items['baseclass']:
                         print('Missing baseclass {0} for {1}'.format(c_name, name))
+                        continue
 
                     complete_class = items['class'][c_name]
                     complete_class.extend(list(element))

--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -22,7 +22,9 @@ from glob import glob
 from xml.etree import ElementTree as et
 from xml.etree.ElementTree import ParseError
 
-COMPENDIUM = 'Compendiums/{category} Compendium.xml'
+PATH_SEP = os.path.sep
+
+COMPENDIUM = PATH_SEP.join(['Compendiums','{category} Compendium.xml'])
 
 
 class XMLCombiner(object):
@@ -231,8 +233,9 @@ def create_category_compendiums():
         # filenames = glob('%s/*.xml' % category)
         filenames = []
 
-        if category is 'Homebrew':  # populate base classes to allow for homebrew archetypes
-            for root, dirnames, fnames in os.walk('Character/Classes'):
+        if category == 'Homebrew':  # populate base classes to allow for homebrew archetypes
+            class_dir = PATH_SEP.join(['Character', 'Classes'])
+            for root, dirnames, fnames in os.walk(class_dir):
                 for filename in [fname for fname in fnmatch.filter(fnames, '*.xml') if "(" not in fname]:
                     class_name = re.search('(.*)\.xml', filename).groups()[0]
                     if args.includes == ['*'] or args.includes == ['Homebrew'] or class_name in args.includes:
@@ -253,14 +256,17 @@ def create_class_compendiums():
     classes = {}
     output_paths = []
 
-    files = glob('Character/Classes/*/*.xml')
+    class_files = PATH_SEP.join(['Character','Classes','*','*.xml'])
+    files = glob(class_files)
 
     if (args.includes == ['*'] and 'HB' not in args.excludes) or 'Homebrew' in args.includes:
-        files += glob('Homebrew/Classes/*/*.xml')
+        homebrew_class_files = PATH_SEP.join(['Homebrew','Classes','*','*.xml'])
+        files += glob(homebrew_class_files)
 
     # Group source xml files into base class
     for file in files:
-        class_name, subclass_name = re.search(r"/([^/]+)/([^/]+)\.xml$", file).groups()
+        sub_class_regex = PATH_SEP.join(["","([^","]+)","([^","]+)\.xml$"])
+        class_name, subclass_name = re.search(sub_class_regex, file).groups()
         if args.includes == ['*'] or (class_name in args.includes):
             if class_name not in classes:
                 classes[class_name] = []

--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -22,7 +22,7 @@ from glob import glob
 from xml.etree import ElementTree as et
 from xml.etree.ElementTree import ParseError
 
-PATH_SEP = os.path.sep
+PATH_SEP = re.escape(os.path.sep)
 
 COMPENDIUM = PATH_SEP.join(['Compendiums','{category} Compendium.xml'])
 

--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -22,7 +22,7 @@ from glob import glob
 from xml.etree import ElementTree as et
 from xml.etree.ElementTree import ParseError
 
-PATH_SEP = re.escape(os.path.sep)
+PATH_SEP = os.path.sep
 
 COMPENDIUM = PATH_SEP.join(['Compendiums','{category} Compendium.xml'])
 
@@ -265,7 +265,7 @@ def create_class_compendiums():
 
     # Group source xml files into base class
     for file in files:
-        sub_class_regex = PATH_SEP.join(["","([^","]+)","([^","]+)\.xml$"])
+        sub_class_regex = re.escape(PATH_SEP).join(["","([^","]+)","([^","]+)\.xml$"])
         class_name, subclass_name = re.search(sub_class_regex, file).groups()
         if args.includes == ['*'] or (class_name in args.includes):
             if class_name not in classes:


### PR DESCRIPTION
Added ability for script to be used on windows by pulling os path separator instead of just using '/', per #413.

Also fixed subclasses getting mixed, per change in #411, so they can be immediately used