### PR TITLE
Fix HB UA tags

### DIFF
--- a/Character/Classes/Mystic/Mystic (Avatar).xml
+++ b/Character/Classes/Mystic/Mystic (Avatar).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Avatar)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Awakened).xml
+++ b/Character/Classes/Mystic/Mystic (Awakened).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Awakened)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Immortal).xml
+++ b/Character/Classes/Mystic/Mystic (Immortal).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Immortal)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Nomad).xml
+++ b/Character/Classes/Mystic/Mystic (Nomad).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Nomad)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Soul Knife).xml
+++ b/Character/Classes/Mystic/Mystic (Soul Knife).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Soul Knife)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic (Wu Jen).xml
+++ b/Character/Classes/Mystic/Mystic (Wu Jen).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Mystic (UA)" UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<subclass baseclass="Mystic (UA)">
 		<name>Mystic (Wu Jen)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Character/Classes/Mystic/Mystic.xml
+++ b/Character/Classes/Mystic/Mystic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<baseclass UA="The Mystic Class">
+<compendium version="5" UA="The Mystic Class">
+	<baseclass>
 		<name>Mystic (UA)</name>
 		<hd>8</hd>
 		<proficiency>Intelligence, Wisdom, Arcana, History, Insight, Medicine, Nature, Perception, Religion</proficiency>

--- a/Homebrew/Classes/Cleric/Cleric (Air).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Air).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Air)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Balance).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Balance).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Balance)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Beauty).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Beauty).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Beauty)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Blood).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Blood).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Blood)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Corruption).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Corruption).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Corruption)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Creation).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Creation).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Creation)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Earth).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Earth).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Earth)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Entropy).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Entropy).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Entropy)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Fire).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Fire).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Fire)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Madness).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Madness).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Madness)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Repose).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Repose).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Repose)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Survival).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Survival).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Survival)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Travel).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Travel).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Travel)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Tyranny).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Tyranny).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Tyranny)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Cleric/Cleric (Water).xml
+++ b/Homebrew/Classes/Cleric/Cleric (Water).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<subclass baseclass="Cleric">
 		<name>Cleric (Water)</name>
 		<autolevel level="1">

--- a/Homebrew/Classes/Fighter/Fighter (Gunslinger).xml
+++ b/Homebrew/Classes/Fighter/Fighter (Gunslinger).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Fighter" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Fighter">
 		<name>Fighter (Gunslinger)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Ascetic).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Ascetic).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Ascetic)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Battle).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Battle).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Battle)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Eagle).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Eagle).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Eagle)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Mercy).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Mercy).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Mercy)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Perfection).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Perfection).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Perfection)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Predation).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Predation).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Predation)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Paladin/Paladin (Providence).xml
+++ b/Homebrew/Classes/Paladin/Paladin (Providence).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Paladin" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Paladin">
 		<name>Paladin (Providence)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Ranger/Ranger (Burghal Explorer).xml
+++ b/Homebrew/Classes/Ranger/Ranger (Burghal Explorer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Ranger" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Ranger">
 		<name>Ranger (Burghal Explorer)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Ranger/Ranger (Wasteland Wanderer).xml
+++ b/Homebrew/Classes/Ranger/Ranger (Wasteland Wanderer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Ranger" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Ranger">
 		<name>Ranger (Wasteland Wanderer)</name>
 		<autolevel level="3">
 			<feature optional="YES">

--- a/Homebrew/Classes/Warlock/Warlock (Genie).xml
+++ b/Homebrew/Classes/Warlock/Warlock (Genie).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Warlock" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Warlock">
 		<name>Warlock (Genie)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Warlock/Warlock (Oracle).xml
+++ b/Homebrew/Classes/Warlock/Warlock (Oracle).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Warlock" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Warlock">
 		<name>Warlock (Oracle)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Classes/Warlock/Warlock (The Chaos).xml
+++ b/Homebrew/Classes/Warlock/Warlock (The Chaos).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
-	<subclass baseclass="Warlock" HB="HB">
+<compendium version="5" HB="HB">
+	<subclass baseclass="Warlock">
 		<name>Warlock (The Chaos)</name>
 		<autolevel level="1">
 			<feature optional="YES">

--- a/Homebrew/Spells/Book of the Righteous.xml
+++ b/Homebrew/Spells/Book of the Righteous.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" HB="HB">
 	<spell>
 		<name>Anwyn's Elysian Palace</name>
 		<level>9</level>

--- a/Unearthed Arcana/Artificer items.xml
+++ b/Unearthed Arcana/Artificer items.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" UA="Artificer">
 	<!-- Artificer Class and Subclass (Specialist) and spells de-duplicated into /Classes,
 but this project doesn't have a good solution to PC Monster and Magic Item compendiums yet -->
 	<item>

--- a/Unearthed Arcana/Demon Summoning.xml
+++ b/Unearthed Arcana/Demon Summoning.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" UA="That Old Black Magic">
 	<spell>
 		<name>Conjure Barlgura</name>
 		<level>4</level>

--- a/Unearthed Arcana/Starter Spells.xml
+++ b/Unearthed Arcana/Starter Spells.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<compendium version="5">
+<compendium version="5" UA="Starter Spells">
 	<spell>
 		<name>Cause Fear (UA)</name>
 		<level>1</level>


### PR DESCRIPTION
In some cases they needed to be moved up a level,
because there were multiple elements under the root tag.

Some HB/UA was still included in Full Compendium, even if they should have been excluded.