### PR TITLE
Give divine soul sorcerer subclass access to cleric spells

### DIFF
--- a/Character/Classes/Sorcerer/Sorcerer (Divine Soul).xml
+++ b/Character/Classes/Sorcerer/Sorcerer (Divine Soul).xml
@@ -46,4 +46,5 @@
 			</feature>
 		</autolevel>
 	</subclass>
+	<borrowSpells fromClass="Cleric" class="Sorcerer (Divine Soul)"/>
 </compendium>


### PR DESCRIPTION
From the divine soul sorcerer description:
> Your link to the divine allows you to learn spells normally associated with the cleric class. When your Spellcasting feature lets you learn a sorcerer cantrip or a sorcerer spell of 1st level or higher, you can choose the new spell from the cleric spell list or the sorcerer spell list. You must otherwise obey all the restrictions for selecting the spell, and it becomes a sorcerer spell for you.
