### PR TITLE
add sidekicks

### DIFF
--- a/Bestiary/Dragon of Icespire Peak.xml
+++ b/Bestiary/Dragon of Icespire Peak.xml
@@ -245,4 +245,815 @@
 			<attack>Ray of Frost|4|1d8</attack>
 		</action>
 	</monster>
+		<monster>
+		<name>Air Elemental Myrmidon</name>
+		<size>M</size>
+		<type>elemental</type>
+		<description>Source: Mordenkainen's Tome of Foes</description>
+		<alignment>neutral</alignment>
+		<ac>18 (plate)</ac>
+		<hp>117 (18d8+36)</hp>
+		<speed>30 ft., fly 30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>9</int>
+		<wis>10</wis>
+		<cha>10</cha>
+		<save />
+		<skill />
+		<resist>lightning, thunder; bludgeoning, piercing, and slashing from nonmagical weapons</resist>
+		<vulnerable />
+		<immune>poison</immune>
+		<conditionImmune>paralyzed, petrified, poisoned, prone</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>10</passive>
+		<languages>Auran, one language of its creator's choice</languages>
+		<cr>7</cr>
+		<trait>
+			<name>Magic Weapons</name>
+			<text>The myrmidon's weapon attacks are magical.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The myrmidon makes three flail attacks.</text>
+		</action>
+		<action>
+			<name>Flail</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8+4) bludgeoning damage.</text>
+			<attack>Flail|7|1d8+4</attack>
+		</action>
+		<action>
+			<name>Lightning Strike (Recharge 6)</name>
+			<text>The myrmidon makes one flail attack. If the attack hits, it deals an extra 18 (4d8) lightning damage, and the target must succeed on a DC 14 Constitution saving throw or be stunned until the end of the myrmidon's next turn.</text>
+			<text />
+			<text>Stunned:</text>
+			<text>• A stunned creature is incapacitated, meaning it can't take actions or reactions, can't move, and can speak only falteringly.</text>
+			<text />
+			<text>• The creature automatically fails Strength and Dexterity saving throws.</text>
+			<text />
+			<text>• Attack rolls against the creature have advantage.</text>
+			<attack>Lightning Strike|7|1d8+4+4d8</attack>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Allip</name>
+		<size>M</size>
+		<type>undead</type>
+		<description>Source: Mordenkainen's Tome of Foes</description>
+		<alignment>neutral evil</alignment>
+		<ac>13</ac>
+		<hp>40 (9d8)</hp>
+		<speed>0 ft., fly 40 ft. (hover)</speed>
+		<str>6</str>
+		<dex>17</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>15</wis>
+		<cha>16</cha>
+		<save>Int +6, Wis +5</save>
+		<skill>Perception +5, Stealth +6</skill>
+		<resist>acid, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune>cold; necrotic, poison</immune>
+		<conditionImmune>charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>15</passive>
+		<languages>the languages it knew in life</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Undead Nature</name>
+			<text>An allip doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Incorporeal Movement</name>
+			<text>The allip can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object.</text>
+		</trait>
+		<action>
+			<name>Maddening Touch</name>
+			<text>Melee Spell Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (4d6 + 3) psychic damage.</text>
+			<attack>Maddening Touch|6|4d6+3</attack>
+		</action>
+		<action>
+			<name>Whispers of Madness</name>
+			<text>The allip chooses up to three creatures it can see within 60 feet of it. Each target must succeed on a DC 14 Wisdom saving throw, or it takes 7 (1d8 + 3) psychic damage and must use its reaction to make a melee weapon attack against one creature of the allip's choice that the allip can see. Constructs and undead are immune to this effect.</text>
+		</action>
+		<action>
+			<name>Howling Babble (Recharge 6)</name>
+			<text>Each creature within 30 feet of the allip that can hear it must make a DC 14 Wisdom saving throw. On a failed save, a target takes 12 (2d8 + 3) psychic damage, and it is stunned until the end of its next turn. On a successful save, it takes half as much damage and isn't stunned. Constructs and undead are immune to this effect.</text>
+			<text />
+			<text>Stunned:</text>
+			<text>• A stunned creature is incapacitated, meaning it can't take actions or reactions, can't move, and can speak only falteringly.</text>
+			<text />
+			<text>• The creature automatically fails Strength and Dexterity saving throws.</text>
+			<text />
+			<text>• Attack rolls against the creature have advantage.</text>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+		<monster>
+		<name>Archer</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Volo's Guide to Monsters</description>
+		<alignment>any alignment</alignment>
+		<ac>16 (studded leather armor)</ac>
+		<hp>75 (10d8+30)</hp>
+		<speed>30 ft.</speed>
+		<str>11</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>11</int>
+		<wis>13</wis>
+		<cha>10</cha>
+		<save />
+		<skill>Acrobatics +6, Perception +5</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>15</passive>
+		<languages>any one language (usually Common)</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Archer's Eye</name>
+			<text>As a bonus action, the archer can add 1d10 to its next attack or damage roll with a longbow or shortbow.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The archer makes two attacks with its longbow.</text>
+		</action>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft. one target. Hit: 7 (1d6+4) piercing damage.</text>
+			<attack>Shortsword|6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft, one target. Hit: 8 (1d8+4) piercing damage.</text>
+			<attack>Longbow|6|1d8+4</attack>
+		</action>
+		<spells />
+	</monster>
+		<monster>
+		<name>Dark Tide Knight</name>
+		<size>M</size>
+		<type>humanoid (human)</type>
+		<description>Source: Princes of the Apocalypse</description>
+		<alignment>lawful evil</alignment>
+		<ac>13</ac>
+		<hp>58 (9d8+18)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>11</wis>
+		<cha>11</cha>
+		<skill>Athletics +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Bonded Mount</name>
+			<text>The knight is magically bound to a beast with an innate swimming speed trained to serve as its mount. While mounted on this beast, the knight gains the beast's senses and ability to breathe underwater. The bonded mount obeys the knight's commands. If its mount dies, the knight can train a new beast to serve as its bonded mount, a process requiring a month.</text>
+		</trait>
+		<trait>
+			<name>Sneak Attack</name>
+			<text>The knight deals an extra 7 (2d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the knight that isn't incapacitated and the knight doesn't have disadvantage on the attack roll.</text>
+			<attack>Sneak Attack||2d6</attack>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The knight makes two shortsword attacks.</text>
+		</action>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>Shortsword|5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Lance</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 9 (1d12 + 3) piercing damage.</text>
+			<attack>Lance|5|1d12+3</attack>
+		</action>
+		<reaction>
+			<name>Uncanny Dodge</name>
+			<text>When an attacker the knight can see hits it with an attack, the knight can halve the damage against it.</text>
+		</reaction>
+	</monster>
+		<monster>
+		<name>Flail Snail</name>
+		<size>L</size>
+		<type>elemental</type>
+		<description>Source: Tomb of Annihilation</description>
+		<alignment>unaligned</alignment>
+		<ac>16 (natural armor)</ac>
+		<hp>52 (5d10 + 25)</hp>
+		<speed>10 ft.</speed>
+		<str>17</str>
+		<dex>5</dex>
+		<con>20</con>
+		<int>3</int>
+		<wis>10</wis>
+		<cha>5</cha>
+		<save />
+		<skill />
+		<resist />
+		<vulnerable />
+		<immune>fire, poison</immune>
+		<conditionImmune>poisoned</conditionImmune>
+		<senses>darkvision 60 ft., tremorsense 60 ft.</senses>
+		<passive>10</passive>
+		<languages>—</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Antimagic Shell</name>
+			<text>The snail has advantage on saving throws against spells, and any creature making a spell attack against the snail has disadvantage on the attack roll. If the snail succeeds on its saving throw against a spell or a spell attack misses it, an additional effect might occur, as determined by rolling a d6:</text>
+			<text>1-2. If the spell affects an area or has multiple targets, it fails and has no effect. If the spell targets only the snail, if has no effect on the snail and is reflected back at the caster, using the spell slot level, spell save DC, attack bonus, and spellcasting abilityofthe caster.</text>
+			<text>3-4. No additional effect.</text>
+			<text>5-6. The snail's shell comverts some of the spell's energy into a burst of destructive force. Each creature within 30 feet ofthe snail must make a DC 15 Constitution saving throw, taking 1d6 force damage per level of the spell on a failed save, or half as much damage on a successful one.</text>
+		</trait>
+		<trait>
+			<name>Flail Tentacles</name>
+			<text>The flail snail has five flail tentacles. Whenever the snail takes 10 damage or more on a single turn, one of its tentacles dies. If even one tentacle remains, the snail regrows all dead ones within 1d4 days. If all its tentacles die, the snail retracts into its shell, gaining total cover, and it begins wailing, a sound that can be heard for 600 feet, stopping only when it dies Sd6 minutes later. Healing magic that restores limbs, such as the regenerate spell, can halt this dying process.</text>
+			<roll>5d6</roll>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The flail snail makes as many Flail Tentacle attacks as it has flail tentacles, all against the same target.</text>
+		</action>
+		<action>
+			<name>Flail Tentacle</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage.</text>
+			<attack>Flail Tentacle|5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Scintillating Shell (Recharges after a Short or Long Rest)</name>
+			<text>The snail's shell emits dazzling, colored light until the endofthe snail's next turn. During this time, the shell sheds bright light in a 30-foot radius and dim light for an additional 30 feet, and creatures that can see the snail have disadvantage on attack rolls against it. In addition, any creature within the bright light and able to see the snail when this power is activated must succeed on a DC 15 Wisdom saving throw or be stunned until the light ends.</text>
+		</action>
+		<action>
+			<name>Shell Defense</name>
+			<text>The flail snail withdraws into its shell, gaining a +4 bonus to AC until it emerges. It can emerge from its shell as a bonus action on its turn.</text>
+		</action>
+	</monster>
+		<monster>
+		<name>Huge Giant Crab</name>
+		<size>H</size>
+		<type>beast</type>
+		<description>Source: Monster Manual</description>
+		<alignment>unaligned</alignment>
+		<ac>15 (natural armor)</ac>
+		<hp>161 (14d12 + 70)</hp>
+		<speed>30 ft., swim 30 ft.</speed>
+		<str>20</str>
+		<dex>15</dex>
+		<con>20</con>
+		<int>1</int>
+		<wis>9</wis>
+		<cha>3</cha>
+		<skill>Stealth +4</skill>
+		<conditionImmune>charmed, frightened, paralyzed</conditionImmune>
+		<senses>blindsight 30 ft.</senses>
+		<passive>9</passive>
+		<cr>8</cr>
+		<trait>
+			<name>Amphibious</name>
+			<text>The crab can breathe air and water.</text>
+		</trait>
+		<action>
+			<name>Claw</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 27 (4d10 + 5) bludgeoning damage, and the target is grappled (escape DC 14). The crab has two claws, each of which can grapple only one target.</text>
+			<attack>Claw|9|4d10+5</attack>
+		</action>
+	</monster>
+		<monster>
+		<name>Kobold Dragonshield</name>
+		<size>S</size>
+		<type>humanoid (kobold)</type>
+		<description>Source: Volo's Guide to Monsters</description>
+		<alignment>lawful evil</alignment>
+		<ac>15 (leather armor, shield)</ac>
+		<hp>44 (8d6+16)</hp>
+		<speed>20 ft.</speed>
+		<str>12</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>8</int>
+		<wis>9</wis>
+		<cha>10</cha>
+		<save />
+		<skill>Perception +1</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses>darkvision 60 ft.</senses>
+		<passive>11</passive>
+		<languages>Common, Draconic</languages>
+		<cr>1</cr>
+		<trait>
+			<name>Dragon's Resistance</name>
+			<text>The kobold has resistance to a type of damage based on the color of dragon that invested it with power (choose or roll a d10): 1-2, acid (black); 3-4, cold (white); 5-6, fire (red); 7-8, lightning (blue); 9-10, poison (green).</text>
+		</trait>
+		<trait>
+			<name>Heart of the Dragon</name>
+			<text>If the kobold is frightened or paralyzed by an effect that allows a saving throw, it can repeat the save at the start of its turn to end the effect on itself and all kobolds within 30 feet of it. Any kobold that benefits from this trait (including the dragonshield) has advantage on its next attack roll.</text>
+		</trait>
+		<trait>
+			<name>Pack Tactics</name>
+			<text>The kobold has advantage on an attack roll against a creature if at least one of the kobold's allies is within 5 feet of the creature and the ally isn't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Sunlight Sensitivity</name>
+			<text>While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The kobold makes two melee attacks.</text>
+		</action>
+		<action>
+			<name>Spear</name>
+			<text>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 it, one target. Hit: 4 (ld6+l) piercing damage, or 5 (ld8+l) piercing damage if used with two hands to make a melee attack.</text>
+			<attack>Spear|3|ld6+l</attack>
+			<attack>Two Handed|2|1d8+1</attack>
+		</action>
+		<spells />
+	</monster>
+		<monster>
+		<name>Kraken Priest</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Volo's Guide to Monsters</description>
+		<alignment>any evil alignment</alignment>
+		<ac>10</ac>
+		<hp>75 (10d8+30)</hp>
+		<speed>30 ft., swim 30 ft.</speed>
+		<str>12</str>
+		<dex>10</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save />
+		<skill>Perception +5</skill>
+		<resist>bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>15</passive>
+		<languages>any two languages</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Amphibious</name>
+			<text>The priest can breathe air and water.</text>
+		</trait>
+		<trait>
+			<name>Innate Spellcasting</name>
+			<text>The priest's spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It can innately cast the following spells, requiring no material components:</text>
+			<text>At will: command, create or destroy water</text>
+			<text>3/day each: control water, darkness, water breathing, water walk</text>
+			<text>1/day each: call lightning, Evard's black tentacles</text>
+		</trait>
+		<action>
+			<name>Thunderous Touch</name>
+			<text>Melee Spell Attack: +5 to hit, reach 5 ft., one creature. Hit: 27 (5d10) thunder damage.</text>
+			<attack>Thunderous Touch|5|5d10</attack>
+		</action>
+		<action>
+			<name>Voice of the Kraken (Recharges after a Short or Long Rest)</name>
+			<text>A kraken speaks through the priest with a thunderous voice audible within 300 feet. Creatures of the priest's choice that can hear the kraken's words (which are spoken in Abyssal, Infernal, or Primordial) must succeed on a DC 14 Charisma saving throw or be frightened for 1 minute. A frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
+		</action>
+		<spells>Command, Create or Destroy Water, Control Water, Darkness, Water Breathing, Water Walk, Call Lightning, Evard's Black Tentacles</spells>
+	</monster>
+		<monster>
+		<name>Lizardfolk Subchief</name>
+		<size>M</size>
+		<type>humanoid (lizardfolk)</type>
+		<description>Source: Ghosts of Saltmarsh</description>
+		<alignment>neutral</alignment>
+		<ac>14 (natural armor)</ac>
+		<hp>52 (8d8 + 16)</hp>
+		<speed>30 ft., swim 30 ft.</speed>
+		<str>14</str>
+		<dex>12</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>16</wis>
+		<cha>12</cha>
+		<save>Wis +5</save>
+		<skill>Athletics +4, Perception +5, Survival +5</skill>
+		<vulnerable />
+		<resist />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>15</passive>
+		<languages>Draconic</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Hold Breath</name>
+			<text>The subchief can hold its breath for 15 minutes.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The subchief is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +S to hit with spell attacks). It has the following cleric spells prepared:</text>
+			<text>Cantrips (at will): light, sacred flame, spare the dying, thaumaturgy</text>
+			<text>1st level (4 slots): command, guiding bolt, purify food and drink</text>
+			<text>2nd level (3 slots): hold person, lesser restoration, silence</text>
+			<text>3rd level (2 slots): bestow curse, dispel magic</text>
+		</trait>
+		<spellAbility>Wisdom</spellAbility>
+		<slots>4,3,2,0,0,0,0,0,0</slots>
+		<spells>Light, Sacred Flame, Spare the Dying, Thaumaturgy, Command, Guiding Bolt, Purify Food and Drink, Hold Person, Lesser Restoration, Silence, Bestow Curse, Dispel Magic</spells>
+		<action>
+			<name>Tooth Dagger</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>Tooth Dagger|4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Jaws of Semuanya (Recharge 5-6)</name>
+			<text>The subchief invokes the primal magic of Semuanya, summoning a spectral maw around a target it can see within 60 feet of it. The target must make a DC 13 Dexterity saving throw, taking 22 (5d8) piercing damage on a failed save, or half as much damage on a successful one. A creature that fails this saving throw is also frightened until the end of its next turn.</text>
+			<attack>Jaws of Semuanya||5d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Lizardfolk Render</name>
+		<size>L</size>
+		<type>humanoid (lizardfolk)</type>
+		<description>Source: Ghosts of Saltmarsh</description>
+		<alignment>neutral</alignment>
+		<ac>15 (natural armor)</ac>
+		<hp>52 (7d10 + 14)</hp>
+		<speed>30 ft., swim 30 ft.</speed>
+		<str>16</str>
+		<dex>10</dex>
+		<con>14</con>
+		<int>7</int>
+		<wis>12</wis>
+		<cha>7</cha>
+		<save />
+		<skill>Athletics +5, Perception +3, Survival +5</skill>
+		<vulnerable />
+		<resist />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>13</passive>
+		<languages>Draconic</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Blood Frenzy</name>
+			<text>The render has advantage on melee attack rolls against any creature that doesn't have all its hit points.</text>
+		</trait>
+		<trait>
+			<name>Hold Breath</name>
+			<text>The render can hold its breath for 15 minutes.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The render makes two attacks: one with its claws and one with its bite.</text>
+		</action>
+		<action>
+			<name>Claws</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 12 (2d8 + 3) slashing damage.</text>
+			<attack>Claws|5|2d8+3</attack>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage.</text>
+			<attack>Bite|5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Rend the Field (Recharge 5-6)</name>
+			<text>The render makes a claw attack against each creature of its choice within 10 feet of it. A creature hit by this attack must succeed on a DC 13 Strength saving throw or be knocked prone.</text>
+		</action>
+	</monster>
+		<monster>
+		<name>Master Thief</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Volo's Guide to Monsters</description>
+		<alignment>any alignment</alignment>
+		<ac>16 (studded leather armor)</ac>
+		<hp>83 (13d8+26)</hp>
+		<speed>30 ft.</speed>
+		<str>11</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>11</wis>
+		<cha>12</cha>
+		<save>Dex +7, Int +3</save>
+		<skill>Acrobatics +7, Athletics +3, Perception +3, Sleight of Hand +7, Stealth +7</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>13</passive>
+		<languages>any one language (usually Common) plus thieves' cant</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On each of its turns, the thief can use a bonus action to take the Dash, Disengage, or Hide action.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>If the thief is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the thief instead takes no damage if it succeeds on the saving throw, and only half damage if it fails.</text>
+		</trait>
+		<trait>
+			<name>Sneak Attack (1/Turn)</name>
+			<text>The thief deals an extra 14 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the thief that isn't incapacitated and the thief doesn't have disadvantage on the attack roll.</text>
+			<attack>Sneak Attack| |4d6</attack>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The thief makes three attacks with its shortsword.</text>
+		</action>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5ft., one target. Hit: 7 (1d6+4) piercing damage.</text>
+			<attack>Shortsword|7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Light Crossbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 8 (1d8+4) piercing damage.</text>
+			<attack>Light Crossbow|7|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Uncanny Dodge</name>
+			<text>The thief halves the damage that it takes from an attack that hits it. The thief must be able to see the attacker.</text>
+		</reaction>
+		<spells />
+	</monster>
+		<monster>
+		<name>Rot Troll</name>
+		<size>L</size>
+		<type>giant</type>
+		<description>Source: Mordenkainen's Tome of Foes</description>
+		<alignment>chaotic evil</alignment>
+		<ac>16 (natural armor)</ac>
+		<hp>138 (12d10+72)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>13</dex>
+		<con>22</con>
+		<int>5</int>
+		<wis>8</wis>
+		<cha>4</cha>
+		<save />
+		<skill>Perception +3</skill>
+		<resist />
+		<vulnerable />
+		<immune>necrotic</immune>
+		<conditionImmune />
+		<senses>darkvision 60 ft.</senses>
+		<passive>13</passive>
+		<languages>Giant</languages>
+		<cr>9</cr>
+		<trait>
+			<name>Rancid Degeneration</name>
+			<text>At the end of each of the troll's turns, each creature within 5 feet of it takes 11 (2d10) necrotic damage, unless the troll has taken acid or fire damage since the end of its last turn.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The troll makes three attacks: one with its bite and two with its claws.</text>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage plus 16 (3d10) necrotic damage.</text>
+			<attack>Bite|8|1d6+4+3d10</attack>
+		</action>
+		<action>
+			<name>Claws</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage plus 5 (1d10) necrotic damage.</text>
+			<attack>Claws|8|2d6+4+1d10</attack>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Skull Flier</name>
+		<size>M</size>
+		<type>construct</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>unaligned</alignment>
+		<ac>16 (natural armor)</ac>
+		<hp>24 (3d8)</hp>
+		<speed>10 ft., fly 50 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>1</int>
+		<wis>10</wis>
+		<cha>3</cha>
+		<save></save>
+		<skill>Stealth +4</skill>
+		<vulnerable></vulnerable>
+		<resist></resist>
+		<immune>poison, psychic</immune>
+		<conditionImmune>charmed, frightened, paralyzed, petrified, poisoned</conditionImmune>
+		<senses>darkvision 60ft.</senses>
+		<passive>10</passive>
+		<languages>—</languages>
+		<cr>1/2</cr>
+		<action>
+			<name>Sting</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.</text>
+			<attack>Sting|4|5</attack>
+			<attack>Sting (poison)||3d6</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Star Spawn Mangler</name>
+		<size>M</size>
+		<type>aberration</type>
+		<description>Source: Mordenkainen's Tome of Foes</description>
+		<alignment>chaotic evil</alignment>
+		<ac>14</ac>
+		<hp>71 (13d8+13)</hp>
+		<speed>40 ft., climb 40 ft.</speed>
+		<str>8</str>
+		<dex>18</dex>
+		<con>12</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>7</cha>
+		<save>Dex +7, Con +4</save>
+		<skill>Stealth +7</skill>
+		<resist>cold</resist>
+		<vulnerable />
+		<immune>psychic</immune>
+		<conditionImmune>charmed, frightened, prone</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>11</passive>
+		<languages>Deep Speech</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Ambush</name>
+			<text>On the first round of each combat, the mangler has advantage on attack rolls against a creature that hasn't taken a turn yet.</text>
+		</trait>
+		<trait>
+			<name>Shadow Stealth</name>
+			<text>While in dim light or darkness, the mangler can take the Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The mangler makes two claw attacks.</text>
+		</action>
+		<action>
+			<name>Claw</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage. If the attack roll has advantage, the target also takes 7 (2d6) psychic damage.</text>
+			<attack>Claw|7|1d8+4</attack>
+		</action>
+		<action>
+			<name>Flurry of Claws (Recharge 4_6)</name>
+			<text>The mangler makes six claw attacks against one target. Either before or after these attacks, it can move up to its speed as a bonus action without provoking opportunity attacks.</text>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Statue of Talos</name>
+		<size>L</size>
+		<type>elemental</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>chaotic evil</alignment>
+		<ac>17 (natural armor)</ac>
+		<hp>147 (14d10 + 70)</hp>
+		<speed>30 ft., fly 60 ft.</speed>
+		<str>19</str>
+		<dex>11</dex>
+		<con>20</con>
+		<int>6</int>
+		<wis>11</wis>
+		<cha>9</cha>
+		<save>Wis +4</save>
+		<skill>Perception +4</skill>
+		<vulnerable></vulnerable>
+		<resist>bludgeoning, piercing, and slashing damage from nonmagical attacks that aren't adamantine</resist>
+		<immune>poison</immune>
+		<conditionImmune>exhaustion, petrified, poisoned</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>14</passive>
+		<languages>Terran</languages>
+		<cr>10</cr>
+		<trait>
+			<name>False Appearance</name>
+			<text>While the statue remains motionless, it is indistinguishable from an inanimate statue.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The statue makes five attacks: one with its headbutt and four with its lightning bolt blades.</text>
+		</action>
+		<action>
+			<name>Headbutt</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage.</text>
+			<attack>Headbutt|8|2d6+4</attack>
+		</action>
+		<action>
+			<name>Lightning Bolt Blades</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) slashing damage.</text>
+			<attack>Lightning Bolt Blades|8|2d4+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Swashbuckler</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Volo's Guide to Monsters</description>
+		<alignment>any non-lawful alignment</alignment>
+		<ac>17 (leather armor)</ac>
+		<hp>66 (12d8+12)</hp>
+		<speed>30 ft.</speed>
+		<str>12</str>
+		<dex>18</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save />
+		<skill>Acrobatics +8, Athletics +5, Persuasion +6</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>10</passive>
+		<languages>any one language (usually Common)</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Lightfooted</name>
+			<text>The swashbuckler can take the Dash or Disengage action as a bonus action on each of its turns.</text>
+		</trait>
+		<trait>
+			<name>Suave Defense</name>
+			<text>While the swashbuckler is wearing light or no armor and wielding no shield, its AC includes its Charisma modifier.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The swashbuckler makes three attacks: one with a dagger and two with its rapier.</text>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4+4) piercing damage.</text>
+			<attack>Dagger|6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Rapier</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8+4) piercing damage.</text>
+			<attack>Rapier|6|1d8+4</attack>
+		</action>
+		<spells />
+	</monster>
+	<monster>
+		<name>Tooth-N-Claw</name>
+		<size>M</size>
+		<type>fiend</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>15 (natural armor)</ac>
+		<hp>45 (7d8 + 14)</hp>
+		<speed>50 ft.</speed>
+		<str>17</str>
+		<dex>12</dex>
+		<con>14</con>
+		<int>6</int>
+		<wis>13</wis>
+		<cha>6</cha>
+		<save></save>
+		<skill>Perception +5</skill>
+		<vulnerable></vulnerable>
+		<resist></resist>
+		<immune>cold</immune>
+		<conditionImmune></conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>15</passive>
+		<languages>understands Infernal but can’t speak it</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Keen Hearing and Smell</name>
+			<text>Tooth-N-Claw has advantage on Wisdom (Perception) checks that rely on hearing or smell.</text>
+		</trait>
+		<trait>
+			<name>Pack Tactics</name>
+			<text>Tooth-N-Claw has advantage on an attack roll against a creature if at least one of its allies is within 5 feet of the creature and the ally isn’t incapacitated.</text>
+		</trait>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 7 (2d6) cold damage.</text>
+			<attack>Bite|5|1d8+3+2d6</attack>
+		</action>
+		<action>
+			<name>Freezing Breath (Recharge 5-6)</name>
+			<text>Tooth-N-Claw exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) cold damage on a failed save, or half as much damage on a successful one.</text>
+			<attack>Freezing Breath||6d6</attack>
+		</action>
+	</monster>
 </compendium>

--- a/Bestiary/Dragon of Icespire Peak.xml
+++ b/Bestiary/Dragon of Icespire Peak.xml
@@ -2183,5 +2183,98 @@
 			<attack>Slash (under 1/2hp)|4|1d8+2</attack>
 		</action>
 	</monster>
-
+	<monster>
+		<name>Lhammaruntosz</name>
+		<size>H</size>
+		<type>dragon</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful good</alignment>
+		<ac>19 (natural armor)</ac>
+		<hp>212 (17d12+102)</hp>
+		<speed>40 ft., fly 80 ft., swim 40 ft.</speed>
+		<str>25</str>
+		<dex>10</dex>
+		<con>23</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>19</cha>
+		<save>Dex +5, Con +11, Wis +7, Cha +9</save>
+		<skill>Insight +7, Perception +12, Stealth +5</skill>
+		<immune>lightning</immune>
+		<senses>blindsight 60 ft., darkvision 120 ft.</senses>
+		<passive>22</passive>
+		<languages>Common, Draconic</languages>
+		<cr>16</cr>
+		<trait>
+			<name>Amphibious</name>
+			<text>The dragon can breathe air and water.</text>
+		</trait>
+		<trait>
+			<name>Legendary Resistance (3/Day)</name>
+			<text>If the dragon fails a saving throw, it can choose to succeed instead.</text>
+		</trait>
+		<trait>
+			<name>Innate Spellcasting</name>
+			<text>Lhammaruntosz’s spellcasting ability is Charisma (spell save DC 17). She can innately cast the following spells, requiring no material components:</text>
+			<text>1/day each: create food and water, detect thoughts, fog cloud, speak with animals</text>
+		</trait>
+		<trait>
+			<name>Regeneration</name>
+			<text>Lhammaruntosz regains 5 hit points at the start of her turn.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Lhammaruntosz is an 8th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 17; +9 to hit with spell attacks). She has the following sorcerer spells prepared:</text>
+			<text>Cantrips (at will): light, mage hand, mending</text>
+			<text>1st level (4 slots): charm person, detect magic, expeditious retreat, sleep</text>
+			<text>2nd level (3 slots): darkness, invisibility,suggestion</text>
+			<text>3rd level (3 slots): dispel magic, protection from energy</text>
+			<text>4th level (2 slots): dimension door, stoneskin</text>
+		</trait>
+		<<spellAbility>Charisma</spellAbility>
+		<slots>4,3,3,2,0,0,0,0,0</slots>
+		<spells>Create Food and Water, Detect Thoughts, Fog Cloud, Speak with Animals, Light, Mage Hand, Mending, Charm Person, Detect Magic, Expeditious Retreat, Sleep, Darkness, Invisibility, Suggestion, Dispel Magic, Protection from Energy, Dimension Door, Stoneskin</spells>
+		<action>
+			<name>Multiattack</name>
+			<text>The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.</text>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage.</text>
+			<attack>Bite|12|2d10+7</attack>
+		</action>
+		<action>
+			<name>Claw</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage.</text>
+			<attack>Claw|12|2d6+7</attack>
+		</action>
+		<action>
+			<name>Tail</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage.</text>
+			<attack>Tail|12|2d8+7</attack>
+		</action>
+		<action>
+			<name>Frightful Presence</name>
+			<text>Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</text>
+		</action>
+		<action>
+			<name>Breath Weapons (Recharge 5-6)</name>
+			<text>The dragon uses one of the following breath weapons.</text>
+			<text>Lightning Breath. The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.</text>
+			<text>Repulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 19 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.</text>
+			<attack>Lightning Breath||12d10</attack>
+		</action>
+		<legendary>
+			<name>Detect</name>
+			<text>The dragon makes a Wisdom (Perception) check.</text>
+		</legendary>
+		<legendary>
+			<name>Tail Attack</name>
+			<text>The dragon makes a tail attack.</text>
+		</legendary>
+		<legendary>
+			<name>Wing Attack (Costs 2 Actions)</name>
+			<text>The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.</text>
+		</legendary>
+	</monster>
 </compendium>

--- a/Bestiary/Dragon of Icespire Peak.xml
+++ b/Bestiary/Dragon of Icespire Peak.xml
@@ -2231,7 +2231,7 @@
 			<text>3rd level (3 slots): dispel magic, protection from energy</text>
 			<text>4th level (2 slots): dimension door, stoneskin</text>
 		</trait>
-		<<spellAbility>Charisma</spellAbility>
+		<spellAbility>Charisma</spellAbility>
 		<slots>4,3,3,2,0,0,0,0,0</slots>
 		<spells>Create Food and Water, Detect Thoughts, Fog Cloud, Speak with Animals, Light, Mage Hand, Mending, Charm Person, Detect Magic, Expeditious Retreat, Sleep, Darkness, Invisibility, Suggestion, Dispel Magic, Protection from Energy, Dimension Door, Stoneskin</spells>
 		<action>

--- a/Bestiary/Dragon of Icespire Peak.xml
+++ b/Bestiary/Dragon of Icespire Peak.xml
@@ -245,7 +245,7 @@
 			<attack>Ray of Frost|4|1d8</attack>
 		</action>
 	</monster>
-		<monster>
+	<monster>
 		<name>Air Elemental Myrmidon</name>
 		<size>M</size>
 		<type>elemental</type>
@@ -354,7 +354,7 @@
 		<spells />
 		<slots />
 	</monster>
-		<monster>
+	<monster>
 		<name>Archer</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
@@ -399,7 +399,7 @@
 		</action>
 		<spells />
 	</monster>
-		<monster>
+	<monster>
 		<name>Dark Tide Knight</name>
 		<size>M</size>
 		<type>humanoid (human)</type>
@@ -446,7 +446,7 @@
 			<text>When an attacker the knight can see hits it with an attack, the knight can halve the damage against it.</text>
 		</reaction>
 	</monster>
-		<monster>
+	<monster>
 		<name>Flail Snail</name>
 		<size>L</size>
 		<type>elemental</type>
@@ -501,7 +501,7 @@
 			<text>The flail snail withdraws into its shell, gaining a +4 bonus to AC until it emerges. It can emerge from its shell as a bonus action on its turn.</text>
 		</action>
 	</monster>
-		<monster>
+	<monster>
 		<name>Huge Giant Crab</name>
 		<size>H</size>
 		<type>beast</type>
@@ -531,7 +531,7 @@
 			<attack>Claw|9|4d10+5</attack>
 		</action>
 	</monster>
-		<monster>
+	<monster>
 		<name>Kobold Dragonshield</name>
 		<size>S</size>
 		<type>humanoid (kobold)</type>
@@ -584,7 +584,7 @@
 		</action>
 		<spells />
 	</monster>
-		<monster>
+	<monster>
 		<name>Kraken Priest</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
@@ -631,7 +631,7 @@
 		</action>
 		<spells>Command, Create or Destroy Water, Control Water, Darkness, Water Breathing, Water Walk, Call Lightning, Evard's Black Tentacles</spells>
 	</monster>
-		<monster>
+	<monster>
 		<name>Lizardfolk Subchief</name>
 		<size>M</size>
 		<type>humanoid (lizardfolk)</type>
@@ -734,7 +734,7 @@
 			<text>The render makes a claw attack against each creature of its choice within 10 feet of it. A creature hit by this attack must succeed on a DC 13 Strength saving throw or be knocked prone.</text>
 		</action>
 	</monster>
-		<monster>
+	<monster>
 		<name>Master Thief</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
@@ -792,7 +792,7 @@
 		</reaction>
 		<spells />
 	</monster>
-		<monster>
+	<monster>
 		<name>Rot Troll</name>
 		<size>L</size>
 		<type>giant</type>
@@ -1056,7 +1056,7 @@
 			<attack>Freezing Breath||6d6</attack>
 		</action>
 	</monster>
-		<monster>
+	<monster>
 		<name>Alkilith</name>
 		<size>M</size>
 		<type>fiend (demon)</type>
@@ -1150,7 +1150,7 @@
 			<text>The assassin vine can animate normal vines and roots on the ground in a 15-foot square within 30 feet of it. These plants turn the ground in that area into difficult terrain. A creature in that area when the effect begins must succeed on a DC 13 Strength saving throw or be restrained by entangling vines and roots. A creature restrained by the plants can use its action to make a DC 13 Strength (Athletics) check, freeing itself on a successful check. The effect ends after 1 minute or when the assassin vine dies or uses Entangling Vines again.</text>
 		</action>
 	</monster>
-		<monster>
+	<monster>
 		<name>Bard</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
@@ -1292,7 +1292,7 @@
 			<text>The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.</text>
 		</legendary>
 	</monster>
-		<monster>
+	<monster>
 		<name>Deathlock Mastermind</name>
 		<size>M</size>
 		<type>undead</type>
@@ -1367,7 +1367,7 @@
 		<spells>Detect Magic, Disguise Self, Mage Armor, Chill Touch, Mage Hand, Minor Illusion, Poison Spray, Arms of Hadar, Blight, Counterspell, Crown of Madness, Darkness, Dimension Door, Dispel Magic, Fly, Hold Monster, Invisibility</spells>
 		<slots>0,0,0,0,2</slots>
 	</monster>
-		<monster>
+	<monster>
 		<name>Giant Skeleton</name>
 		<size>H</size>
 		<type>undead</type>
@@ -1855,7 +1855,7 @@
 		</action>
 		<spells />
 	</monster>
-		<monster>
+	<monster>
 		<name>Blackguard</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
@@ -2089,7 +2089,7 @@
 			<text>The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon.</text>
 		</reaction>
 	</monster>
-		<monster>
+	<monster>
 		<name>Sacred Statue</name>
 		<size>L</size>
 		<type>construct</type>
@@ -2143,7 +2143,7 @@
 		<spells />
 		<slots />
 	</monster>
-		<monster>
+	<monster>
 		<name>Skeletal Swarm</name>
 		<size>L</size>
 		<type>swarm of medium undead</type>

--- a/Bestiary/Dragon of Icespire Peak.xml
+++ b/Bestiary/Dragon of Icespire Peak.xml
@@ -249,7 +249,7 @@
 		<name>Air Elemental Myrmidon</name>
 		<size>M</size>
 		<type>elemental</type>
-		<description>Source: Mordenkainen's Tome of Foes</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>neutral</alignment>
 		<ac>18 (plate)</ac>
 		<hp>117 (18d8+36)</hp>
@@ -302,7 +302,7 @@
 		<name>Allip</name>
 		<size>M</size>
 		<type>undead</type>
-		<description>Source: Mordenkainen's Tome of Foes</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>neutral evil</alignment>
 		<ac>13</ac>
 		<hp>40 (9d8)</hp>
@@ -358,7 +358,7 @@
 		<name>Archer</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
-		<description>Source: Volo's Guide to Monsters</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>any alignment</alignment>
 		<ac>16 (studded leather armor)</ac>
 		<hp>75 (10d8+30)</hp>
@@ -403,7 +403,7 @@
 		<name>Dark Tide Knight</name>
 		<size>M</size>
 		<type>humanoid (human)</type>
-		<description>Source: Princes of the Apocalypse</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>lawful evil</alignment>
 		<ac>13</ac>
 		<hp>58 (9d8+18)</hp>
@@ -450,7 +450,7 @@
 		<name>Flail Snail</name>
 		<size>L</size>
 		<type>elemental</type>
-		<description>Source: Tomb of Annihilation</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>unaligned</alignment>
 		<ac>16 (natural armor)</ac>
 		<hp>52 (5d10 + 25)</hp>
@@ -505,7 +505,7 @@
 		<name>Huge Giant Crab</name>
 		<size>H</size>
 		<type>beast</type>
-		<description>Source: Monster Manual</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>unaligned</alignment>
 		<ac>15 (natural armor)</ac>
 		<hp>161 (14d12 + 70)</hp>
@@ -535,7 +535,7 @@
 		<name>Kobold Dragonshield</name>
 		<size>S</size>
 		<type>humanoid (kobold)</type>
-		<description>Source: Volo's Guide to Monsters</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>lawful evil</alignment>
 		<ac>15 (leather armor, shield)</ac>
 		<hp>44 (8d6+16)</hp>
@@ -588,7 +588,7 @@
 		<name>Kraken Priest</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
-		<description>Source: Volo's Guide to Monsters</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>any evil alignment</alignment>
 		<ac>10</ac>
 		<hp>75 (10d8+30)</hp>
@@ -635,7 +635,7 @@
 		<name>Lizardfolk Subchief</name>
 		<size>M</size>
 		<type>humanoid (lizardfolk)</type>
-		<description>Source: Ghosts of Saltmarsh</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>neutral</alignment>
 		<ac>14 (natural armor)</ac>
 		<hp>52 (8d8 + 16)</hp>
@@ -686,7 +686,7 @@
 		<name>Lizardfolk Render</name>
 		<size>L</size>
 		<type>humanoid (lizardfolk)</type>
-		<description>Source: Ghosts of Saltmarsh</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>neutral</alignment>
 		<ac>15 (natural armor)</ac>
 		<hp>52 (7d10 + 14)</hp>
@@ -738,7 +738,7 @@
 		<name>Master Thief</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
-		<description>Source: Volo's Guide to Monsters</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>any alignment</alignment>
 		<ac>16 (studded leather armor)</ac>
 		<hp>83 (13d8+26)</hp>
@@ -796,7 +796,7 @@
 		<name>Rot Troll</name>
 		<size>L</size>
 		<type>giant</type>
-		<description>Source: Mordenkainen's Tome of Foes</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>chaotic evil</alignment>
 		<ac>16 (natural armor)</ac>
 		<hp>138 (12d10+72)</hp>
@@ -874,7 +874,7 @@
 		<name>Star Spawn Mangler</name>
 		<size>M</size>
 		<type>aberration</type>
-		<description>Source: Mordenkainen's Tome of Foes</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>chaotic evil</alignment>
 		<ac>14</ac>
 		<hp>71 (13d8+13)</hp>
@@ -967,7 +967,7 @@
 		<name>Swashbuckler</name>
 		<size>M</size>
 		<type>humanoid (any race)</type>
-		<description>Source: Volo's Guide to Monsters</description>
+		<description>Source: Dragon of Icespire Peak</description>
 		<alignment>any non-lawful alignment</alignment>
 		<ac>17 (leather armor)</ac>
 		<hp>66 (12d8+12)</hp>
@@ -1055,5 +1055,804 @@
 			<text>Tooth-N-Claw exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) cold damage on a failed save, or half as much damage on a successful one.</text>
 			<attack>Freezing Breath||6d6</attack>
 		</action>
+	</monster>
+		<monster>
+		<name>Alkilith</name>
+		<size>M</size>
+		<type>fiend (demon)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>chaotic evil</alignment>
+		<ac>17 (natural armor)</ac>
+		<hp>157 (15d8+90)</hp>
+		<speed>40 ft.</speed>
+		<str>12</str>
+		<dex>19</dex>
+		<con>22</con>
+		<int>6</int>
+		<wis>11</wis>
+		<cha>7</cha>
+		<save>Dex +8, Con +10</save>
+		<skill>Stealth +8</skill>
+		<resist>acid, cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune>poison</immune>
+		<conditionImmune>charmed, frightened, poisoned</conditionImmune>
+		<senses>darkvision 120 ft.</senses>
+		<passive>10</passive>
+		<languages>understands Abyssal but can't speak</languages>
+		<cr>11</cr>
+		<trait>
+			<name>Amorphous</name>
+			<text>The alkilith can move through a space as narrow as 1 inch wide without squeezing.</text>
+		</trait>
+		<trait>
+			<name>False Appearance</name>
+			<text>While the alkilith is motionless, it is indistinguishable from an ordinary slime or fungus.</text>
+		</trait>
+		<trait>
+			<name>Foment Madness</name>
+			<text>Any creature that isn't a demon that starts its turn within 30 feet of the alkilith must succeed on a DC 18 Wisdom saving throw, or it hears a faint buzzing in its head for a moment and has disadvantage on its next attack roll, saving throw, or ability check.</text>
+			<text>If the saving throw against Foment Madness fails by 5 or more, the creature is instead subjected to the confusion spell for 1 minute (no concentration required by the alkilith). While under the effect of that confusion, the creature is immune to Foment Madness.</text>
+		</trait>
+		<trait>
+			<name>Magic Resistance</name>
+			<text>The alkilith has advantage on saving throws against spells and other magical effects.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The alkilith makes three tentacle attacks.</text>
+		</action>
+		<action>
+			<name>Tentacle</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 15 ft., one target. Hit: 18 (4d6 + 4) acid damage.</text>
+			<attack>Tentacle|8|4d6+4</attack>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Assassin Vine</name>
+		<size>L</size>
+		<type>plant</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>unaligned</alignment>
+		<ac>13 (natural armor)</ac>
+		<hp>85 (10d10 + 30)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>10</dex>
+		<con>16</con>
+		<int>1</int>
+		<wis>10</wis>
+		<cha>1</cha>
+		<save />
+		<skill />
+		<resist>cold, fire</resist>
+		<immune />
+		<conditionImmune>blinded, deafened, exhaustion, prone</conditionImmune>
+		<vulnerable />
+		<senses>blindsight 30 ft.</senses>
+		<passive>10</passive>
+		<languages>—</languages>
+		<cr>3</cr>
+		<trait>
+			<name>False Appearance</name>
+			<text>While the assassin vine remains motionless, it is indistinguishable from a normal plant.</text>
+		</trait>
+		<action>
+			<name>Constrict</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 20 ft., one creature. Hit: The target takes 11 (2d6 + 4) bludgeoning damage, and It is grappled (escape DC 14). Until this grapple ends, the target is restrained, and it takes 21 (6d6) poison damage at the start of each of its turns. The vine can constrict only one target at a time.</text>
+			<attack>Constrict|6|2d6+4</attack>
+			<attack>Poison Damage||6d6</attack>
+		</action>
+		<action>
+			<name>Entangling Vines</name>
+			<text>The assassin vine can animate normal vines and roots on the ground in a 15-foot square within 30 feet of it. These plants turn the ground in that area into difficult terrain. A creature in that area when the effect begins must succeed on a DC 13 Strength saving throw or be restrained by entangling vines and roots. A creature restrained by the plants can use its action to make a DC 13 Strength (Athletics) check, freeing itself on a successful check. The effect ends after 1 minute or when the assassin vine dies or uses Entangling Vines again.</text>
+		</action>
+	</monster>
+		<monster>
+		<name>Bard</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>any alignment</alignment>
+		<ac>15 (chain shirt)</ac>
+		<hp>44 (8d8+8)</hp>
+		<speed>30 ft.</speed>
+		<str>11</str>
+		<dex>14</dex>
+		<con>12</con>
+		<int>10</int>
+		<wis>13</wis>
+		<cha>14</cha>
+		<save>Dex +4, Wis +3</save>
+		<skill>Acrobatics +4, Perception +5, Performance +6</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>15</passive>
+		<languages>any two languages</languages>
+		<cr>2</cr>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The bard is a 4th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 12, +4 to hit with spell attacks). It has the following bard spells prepared:</text>
+			<text>Cantrips (at will): friends, mage hand, vicious mockery</text>
+			<text>1st level (4 slots): charm person, healing word, heroism, sleep, thunderwave</text>
+			<text>2nd level (3 slots): invisibility, shatter</text>
+		</trait>
+		<trait>
+			<name>Song of Rest</name>
+			<text>The bard can perform a song while taking a short rest. Any ally who hears the song regains an extra ld6 hit points if it spends any Hit Dice to regain hit points at the end of that rest. The bard can confer this benefit on itself as well.</text>
+		</trait>
+		<trait>
+			<name>Taunt (2/day)</name>
+			<text>The bard can use a bonus action on its turn to target one creature within 30 feet of it. If the target can hear the bard, the target must succeed on a DC 12 Charisma saving throw or have disadvantage on ability checks, attack rolls, and saving throws until the start of the bard's next turn.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6+2) piercing damage.</text>
+			<attack>Shortsword|4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one: target. Hit: 5 (1d6+2) piercing damage.</text>
+			<attack>Shortbow|4|1d6+2</attack>
+		</action>
+		<spells>Friends, Mage Hand, Vicious Mockery, Charm Person, Healing Word, Heroism, Sleep, Thunderwave, Invisibility, Shatter</spells>
+		<slots>4,3,0,0,0,0,0,0,0</slots>
+	</monster>
+	<monster>
+		<name>Claugiyliamatar</name>
+		<size>G</size>
+		<type>dragon</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>21 (natural armor)</ac>
+		<hp>385 (22d20+154)</hp>
+		<speed>40 ft., fly 80 ft., swim 40 ft.</speed>
+		<str>27</str>
+		<dex>12</dex>
+		<con>25</con>
+		<int>20</int>
+		<wis>17</wis>
+		<cha>19</cha>
+		<save>Dex +8, Con +14, Wis +10, Cha +11</save>
+		<skill>Deception +11, Insight +10, Perception +17, Persuasion +11, Stealth +8</skill>
+		<immune>poison</immune>
+		<conditionImmune>poisoned</conditionImmune>
+		<senses>blindsight 60 ft., darkvision 120 ft.</senses>
+		<passive>27</passive>
+		<languages>Common, Draconic</languages>
+		<cr>23</cr>
+		<trait>
+			<name>Amphibious</name>
+			<text>The dragon can breathe air and water.</text>
+		</trait>
+		<trait>
+			<name>Legendary Resistance (3/Day)</name>
+			<text>If the dragon fails a saving throw, it can choose to succeed instead.</text>
+		</trait>
+		<trait>
+			<name>Innate Spellcasting</name>
+			<text>Claugiyliamatar’s spellcasting ability is Charisma (spell save DC 19). She can innately cast the following spells, requiring no material components:</text>
+			<text>1/day each: invisibility, legend lore, protection from energy, true seeing</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Claugiyliamatar is an 8th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 18; +10 to hit with spell attacks). She has the following druid spells prepared:</text>
+			<text>Cantrips (at will): druidcraft, mending, produce flame</text>
+			<text>1st level (4 slots): cure wounds, detect magic, entangle, speak with animals</text>
+			<text>2nd level (3 slots): animal messenger, pass without trace</text>
+			<text>3rd level (3 slots): dispel magic, plant growth</text>
+			<text>4th level (2 slots): blight, locate creature, stoneskin</text>
+		</trait>
+		<spellAbility>Wisdom</spellAbility>
+		<slots>4,3,3,2,0,0,0,0,0</slots>
+		<spells>Druidcraft, Mending, Produce Flame, Cure Wounds, Detect Magic, Entangle, Speak with Animals, Animal Messenger, Pass without Trace, Dispel Magic, Plant Growth, Blight, Locate Creature, Stoneskin</spells>
+		<action>
+			<name>Multiattack</name>
+			<text>The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.</text>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 10 (3d6) poison damage.</text>
+			<attack>Bite|15|2d10+8+3d6</attack>
+		</action>
+		<action>
+			<name>Claw</name>
+			<text>Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 22 (4d6 + 8) slashing damage.</text>
+			<attack>Claw|15|4d6+8</attack>
+		</action>
+		<action>
+			<name>Tail</name>
+			<text>Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.</text>
+			<attack>Tail|15|2d8+8</attack>
+		</action>
+		<action>
+			<name>Frightful Presence</name>
+			<text>Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</text>
+		</action>
+		<action>
+			<name>Poison Breath (Recharge 5-6)</name>
+			<text>The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one.</text>
+			<attack>Poison Breath||22d6</attack>
+		</action>
+		<legendary>
+			<name>Detect</name>
+			<text>The dragon makes a Wisdom (Perception) check.</text>
+		</legendary>
+		<legendary>
+			<name>Tail Attack</name>
+			<text>The dragon makes a tail attack.</text>
+		</legendary>
+		<legendary>
+			<name>Wing Attack (Costs 2 Actions)</name>
+			<text>The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.</text>
+		</legendary>
+	</monster>
+		<monster>
+		<name>Deathlock Mastermind</name>
+		<size>M</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>neutral evil</alignment>
+		<ac>13 (16 with mage armor)</ac>
+		<hp>110 (20d8+20)</hp>
+		<speed>30 ft.</speed>
+		<str>11</str>
+		<dex>16</dex>
+		<con>12</con>
+		<int>15</int>
+		<wis>12</wis>
+		<cha>17</cha>
+		<save>Int +5, Cha +6</save>
+		<skill>Arcana +5, History +5, Perception +4</skill>
+		<resist>necrotic; bludgeoning, piercing, and slashing from nonmagical attacks that aren't silvered</resist>
+		<vulnerable />
+		<immune>poison</immune>
+		<conditionImmune>exhaustion, poisoned</conditionImmune>
+		<senses>darkvision 120 ft. (including magical darkness)</senses>
+		<passive>14</passive>
+		<languages>the languages it knew in life</languages>
+		<cr>8</cr>
+		<trait>
+			<name>Undead Nature</name>
+			<text>A deathlock doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Innate Spellcasting</name>
+			<text>The deathlock's innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components:</text>
+			<text>At will: detect magic, disguise self, mage armor.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The deathlock is a 10th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). It regains its expended spell slots when it finishes a short or long rest. It knows the following warlock spells:</text>
+			<text />
+			<text>Cantrips (at will): chill touch, mage hand, minor illusion, poison spray</text>
+			<text>1st–5th level (2 5th-level slots): arms of Hadar, blight, counterspell, crown of madness, darkness, dimension door, dispel magic, fly, hold monster, invisibility</text>
+		</trait>
+		<trait>
+			<name>Turn Resistance</name>
+			<text>The deathlock has advantage on saving throws against any effect that turns undead.</text>
+		</trait>
+		<trait>
+			<name>Variant: Patron-Specific Spells</name>
+			<text>You can customize a deathlock mastermind by replacing some or all of the spells in its Spellcasting trait with spells specific to its patron. Here are examples.</text>
+			<text />
+			<text>Archfey patron: blink, dominate beast, dominate person, faerie fire, greater invisibility, hunger of Hadar, hypnotic pattern, phantasmal force, seeming, sleep</text>
+			<text />
+			<text>Fiend patron: blindness/deafness, burning hands, command, fire shield, fireball, flame strike, hellish rebuke, scorching ray, stinking cloud, wall of fire</text>
+			<text />
+			<text>Great Old One patron: clairvoyance, detect thoughts, dissonant whispers, dominate person, Evard's black tentacles, hunger of Hadar, phantasmal force, sending, Tasha's tasha's hideous laughter, telekinesis</text>
+		</trait>
+		<action>
+			<name>Deathly Claw</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (3d6 + 3 necrotic damage).</text>
+			<attack>Deathly Claw|6|3d6+3</attack>
+		</action>
+		<action>
+			<name>Grave Bolts</name>
+			<text>Ranged Spell Attack: +6 to hit, range 120 ft., one or two targets. Hit: 18 (4d8) necrotic damage. If the target is Large or smaller, it must succeed on a DC 16 Strength saving throw or become restrained as shadowy tendrils wrap around it for 1 minute. A restrained target can use its action to repeat the saving throw, ending the effect on itself on a success.</text>
+			<text />
+			<text>Restrained:</text>
+			<text>• A restrained creature's speed becomes 0, and it can't benefit from any bonus to its speed.</text>
+			<text />
+			<text>• Attack rolls against the creature have advantage, and the creature's attack rolls have disadvantage.</text>
+			<text />
+			<text>• The creature has disadvantage on Dexterity saving throws.</text>
+			<attack>Grave Bolts|6|4d8</attack>
+		</action>
+		<spells>Detect Magic, Disguise Self, Mage Armor, Chill Touch, Mage Hand, Minor Illusion, Poison Spray, Arms of Hadar, Blight, Counterspell, Crown of Madness, Darkness, Dimension Door, Dispel Magic, Fly, Hold Monster, Invisibility</spells>
+		<slots>0,0,0,0,2</slots>
+	</monster>
+		<monster>
+		<name>Giant Skeleton</name>
+		<size>H</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>neutral evil</alignment>
+		<ac>17 (natural armor)</ac>
+		<hp>115 (10d12 + 50)</hp>
+		<speed>30 ft.</speed>
+		<str>21</str>
+		<dex>10</dex>
+		<con>20</con>
+		<int>4</int>
+		<wis>6</wis>
+		<cha>6</cha>
+		<vulnerable>bludgeoning</vulnerable>
+		<immune>poison</immune>
+		<conditionImmune>exhaustion, poisoned</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>8</passive>
+		<languages>understands Giant but can’t speak</languages>
+		<cr>7</cr>
+		<trait>
+			<name>Evasion</name>
+			<text>If the skeleton is subjected to an effect that allows it to make a saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails.</text>
+		</trait>
+		<trait>
+			<name>Magic Resistance</name>
+			<text>The skeleton has advantage on saving throws against spells and other magical effects.</text>
+		</trait>
+		<trait>
+			<name>Turn Immunity</name>
+			<text>The skeleton is immune to effects that turn undead.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The skeleton makes three scimitar attacks.</text>
+		</action>
+		<action>
+			<name>Scimitar</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 15 (3d6 + 5) slashing damage.</text>
+			<attack>Scimitar|8|3d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Greater Zombie</name>
+		<size>M</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>neutral evil</alignment>
+		<ac>15 (natural armor)</ac>
+		<hp>97 (13d8+39)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>10</dex>
+		<con>17</con>
+		<int>4</int>
+		<wis>6</wis>
+		<cha>6</cha>
+		<save>Wis + 1</save>
+		<skill />
+		<resist>cold, necrotic</resist>
+		<vulnerable />
+		<immune>poison</immune>
+		<conditionImmune>charmed, exhaustion, frightened, paralyzed, poisoned</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>8</passive>
+		<languages>understands the languages it knew in life but can't speak</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Source</name>
+			<text>Tales from the Yawning Portal,  page 237</text>
+		</trait>
+		<trait>
+			<name>Undead Nature</name>
+			<text>A zombie doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Turn Resistance</name>
+			<text>The zombie has advantage on saving throws against any effect that turns undead.</text>
+		</trait>
+		<trait>
+			<name>Undead Fortitude</name>
+			<text>If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The zombie makes two melee attacks.</text>
+		</action>
+		<action>
+			<name>Empowered Slam</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage and 7 (2d6) necrotic damage.</text>
+			<attack>Empowered Slam|7|1d6+4</attack>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Master Thief</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>any alignment</alignment>
+		<ac>16 (studded leather armor)</ac>
+		<hp>83 (13d8+26)</hp>
+		<speed>30 ft.</speed>
+		<str>11</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>11</wis>
+		<cha>12</cha>
+		<save>Dex +7, Int +3</save>
+		<skill>Acrobatics +7, Athletics +3, Perception +3, Sleight of Hand +7, Stealth +7</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>13</passive>
+		<languages>any one language (usually Common) plus thieves' cant</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On each of its turns, the thief can use a bonus action to take the Dash, Disengage, or Hide action.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>If the thief is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the thief instead takes no damage if it succeeds on the saving throw, and only half damage if it fails.</text>
+		</trait>
+		<trait>
+			<name>Sneak Attack (1/Turn)</name>
+			<text>The thief deals an extra 14 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of the thief that isn't incapacitated and the thief doesn't have disadvantage on the attack roll.</text>
+			<attack>Sneak Attack| |4d6</attack>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The thief makes three attacks with its shortsword.</text>
+		</action>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5ft., one target. Hit: 7 (1d6+4) piercing damage.</text>
+			<attack>Shortsword|7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Light Crossbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 8 (1d8+4) piercing damage.</text>
+			<attack>Light Crossbow|7|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Uncanny Dodge</name>
+			<text>The thief halves the damage that it takes from an attack that hits it. The thief must be able to see the attacker.</text>
+		</reaction>
+		<spells />
+	</monster>
+	<monster>
+		<name>Sahuagin Blademaster</name>
+		<size>M</size>
+		<type>humanoid (sahuagun)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>20 (plate armor and shield)</ac>
+		<hp>97 (15d8 + 30)</hp>
+		<speed>30 ft., swim 40 ft.</speed>
+		<str>16</str>
+		<dex>12</dex>
+		<con>14</con>
+		<int>12</int>
+		<wis>11</wis>
+		<cha>12</cha>
+		<save>Str +6, Con +5</save>
+		<skill>Athletics +6, Intimidation +4</skill>
+		<vulnerable />
+		<resist />
+		<immune />
+		<conditionImmune />
+		<senses>darkvision 120 ft.</senses>
+		<passive>10</passive>
+		<languages>Sahuagin</languages>
+		<cr>6</cr>
+		<trait>
+			<name>Blood Frenzy</name>
+			<text>The blademaster has advantage on melee attack rolls against any creature that doesn't have all its hit points.</text>
+		</trait>
+		<trait>
+			<name>Limited Amphibiousness</name>
+			<text>The blademaster can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating.</text>
+		</trait>
+		<trait>
+			<name>Shark Telepathy</name>
+			<text>The blademaster can magically command any shark within 120 feet of it, using a limited tele pathy.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The blademaster makes three attacks with its wavecutter blade, or one attack with its bite and two with its claws.</text>
+		</action>
+		<action>
+			<name>Wavecutter Blade</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d8 + 3) slashing damage.</text>
+			<attack>Wavecutter Blade|5|2d8+3</attack>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage.</text>
+			<attack>Bite|6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Claws</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage.</text>
+			<attack>Claws|6|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sahuagin High Priestess</name>
+		<size>M</size>
+		<type>humanoid (sahuagin)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>14 (natural armor)</ac>
+		<hp>71 (11d8 + 22)</hp>
+		<speed>30 ft., swim 40 ft.</speed>
+		<str>14</str>
+		<dex>12</dex>
+		<con>14</con>
+		<int>12</int>
+		<wis>15</wis>
+		<cha>10</cha>
+		<save>Wis +6</save>
+		<skill>Insight +6, Perception +6</skill>
+		<vulnerable />
+		<resist />
+		<immune />
+		<conditionImmune />
+		<senses>darkvision 120 ft.</senses>
+		<passive>16</passive>
+		<languages>Sahuagin</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Blood Frenzy</name>
+			<text>The high priestess has advantage on melee attack rolls against any creature that doesn't have all its hit points.</text>
+		</trait>
+		<trait>
+			<name>Limited Amphibiousness</name>
+			<text>The high priestess can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating.</text>
+		</trait>
+		<trait>
+			<name>Shark Telepathy</name>
+			<text>The high priestess can magically command any shark within 120 feet of it, using a limited tele pathy.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The high priestess is a 7th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has the following cleric spells prepared:</text>
+			<text>Cantrips (at will): guidance, mending, resistance, thaumaturgy</text>
+			<text>1st level (4 slots): bless, detect magic, guiding bolt</text>
+			<text>2nd level (3 slots): hold person, spiritual weapon (trident)</text>
+			<text>3rd level (3 slots): bestow curse, fear, mass healing word, tongues</text>
+			<text>4th level (1 slot): banishment</text>
+		</trait>
+		<spellAbility>Wisdom</spellAbility>
+		<slots>4,3,3,1,0,0,0,0,0</slots>
+		<spells>Guidance, Mending, Resistance, Thaumaturgy, Bless, Detect Magic, Guiding Bolt, Hold Person, Spiritual Weapon, Bestow Curse, Fear, Mass Healing Word, Tongues, Banishment</spells>
+		<action>
+			<name>Multiattack</name>
+			<text>The high priestess makes two attacks with her toothsome staff, or one attack with her bite and one with her claws.</text>
+		</action>
+		<action>
+			<name>Toothsome Staff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 11 (2d8 + 2) piercing damage.</text>
+			<attack>Toothsome Staff|5|2d8+2</attack>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>Bite|5|1d4+2</attack>
+		</action>
+		<action>
+			<name>Claws</name>
+			<text>Melee Weapon Attack: +5 to hit. reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage.</text>
+			<attack>Claws|5|1d4+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sword Wraith Commander</name>
+		<size>M</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>18 (breastplate, shield)</ac>
+		<hp>127 (15d8+60)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>18</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>14</cha>
+		<save />
+		<skill>Perception +4</skill>
+		<resist>necrotic; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune>poison</immune>
+		<conditionImmune>exhaustion, frightened, poisoned, unconscious</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>14</passive>
+		<languages>the languages it knew in life</languages>
+		<cr>8</cr>
+		<trait>
+			<name>Undead Nature</name>
+			<text>A sword wraith doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Martial Fury</name>
+			<text>As a bonus action, the sword wraith can make one weapon attack, which deals an extra 9 (2d8) necrotic damage on a hit. If it does so, attack rolls against it have advantage until the start of its next turn.</text>
+		</trait>
+		<trait>
+			<name>Turning Defiance</name>
+			<text>The sword wraith and any other sword wraiths within 30 feet of it have advantage on saving throws against effects that turn undead.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The sword wraith makes two weapon attacks.</text>
+		</action>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage, or 9 (1d10 + 4) slashing damage if used with two hands.</text>
+			<attack>Longsword|7|1d8+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>Longbow|5|1d8+2</attack>
+		</action>
+		<action>
+			<name>Call to Honor (1/Day)</name>
+			<text>To use this action, the sword wraith must have taken damage during the current combat. If the sword wraith can use this action, it gives itself advantage on attack rolls until the end of its next turn, and 1d4 + 1 sword wraith warriors appear in unoccupied spaces within 30 feet of it. The warriors last until they drop to 0 hit points, and they take their turns immediately after the commander's turn on the same initiative count.</text>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Sword Wraith Warrior</name>
+		<size>M</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45 (6d8+18)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>12</dex>
+		<con>17</con>
+		<int>6</int>
+		<wis>9</wis>
+		<cha>10</cha>
+		<save />
+		<skill />
+		<resist>necrotic; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune>poison</immune>
+		<conditionImmune>exhaustion, frightened, poisoned, unconscious</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>9</passive>
+		<languages>the languages it knew in life</languages>
+		<cr>3</cr>
+		<trait>
+			<name>Undead Nature</name>
+			<text>A sword wraith doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Martial Fury</name>
+			<text>As a bonus action, the sword wraith can make one weapon attack. If it does so, attack rolls against it have advantage until the start of its next turn.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage, or 9 (1d10 + 4) slashing damage if used with two hands.</text>
+			<attack>Longsword|6|1d8+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>Longbow|3|1d8+1</attack>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>War Priest</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>any alignment</alignment>
+		<ac>18 (plate)</ac>
+		<hp>117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<str>16</str>
+		<dex>10</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>17</wis>
+		<cha>13</cha>
+		<save>Con +6, Wis +7</save>
+		<skill>Intimidation +5, Religion +4</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>13</passive>
+		<languages>any two languages</languages>
+		<cr>9</cr>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The priest is a 9th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). It has the following cleric spells prepared:</text>
+			<text>Cantrips (at will): light, mending, sacred flame, spare the dying</text>
+			<text>1st level (4 slots): divine favor, guiding bolt, healing word, shield of faith</text>
+			<text>2nd level (3 slots): lesser restoration, magic weapon, prayer of healing, silence, spiritual weapon</text>
+			<text>3rd level (3 slots): beacon of hope, crusader's mantle, dispel magic, revivify, spirit guardians, water walk</text>
+			<text>4th level (3 slots): banishment, freedom of movement, guardian of faith, stoneskin</text>
+			<text>5th level (1 slot): flame strike, mass cure wounds, hold monster</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The priest makes two melee attacks.</text>
+		</action>
+		<action>
+			<name>Maul</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (2d6 +3) bludgeoning damage.</text>
+			<attack>Maul|7|2d6 +3</attack>
+		</action>
+		<reaction>
+			<name>Guided Strike (Recharges after a Short or Long Rest)</name>
+			<text>The priest grants a +10 bonus to an attack roll made by itself or another creature within 30 feet of it. The priest can make this choice after the roll is made but before it hits or misses.</text>
+		</reaction>
+		<spells>Light, Mending, Sacred Flame, Spare the Dying, Divine Favor, Guiding Bolt, Healing Word, Shield of Faith, Lesser Restoration, Magic Weapon, Prayer of Healing, Silence, Spiritual Weapon, Beacon of Hope, Crusader's Mantle, Dispel Magic, Revivify, Spirit Guardians, Water Walk, Banishment, Freedom of Movement, Guardian of Faith, Stoneskin, Flame Strike, Mass Cure Wounds, Hold Monster</spells>
+		<slots>4,3,3,3,1,0,0,0,0</slots>
+	</monster>
+	<monster>
+		<name>Wood Woad</name>
+		<size>M</size>
+		<type>plant</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful neutral</alignment>
+		<ac>18 (natural armor, shield)</ac>
+		<hp>75 (10d8+30)</hp>
+		<speed>30 ft., climb 30 ft.</speed>
+		<str>18</str>
+		<dex>12</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>13</wis>
+		<cha>8</cha>
+		<save />
+		<skill>Athletics +7, Perception +4, Stealth +4</skill>
+		<resist>bludgeoning, piercing</resist>
+		<vulnerable>fire</vulnerable>
+		<immune />
+		<conditionImmune>charmed, frightened</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>14</passive>
+		<languages>Sylvan</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Magic Club</name>
+			<text>In the wood woad's hand, its club is magical and deals 7 (3d4) extra damage (included in its attacks).</text>
+		</trait>
+		<trait>
+			<name>Plant Camouflage</name>
+			<text>The wood woad has advantage on Dexterity (Stealth) checks it makes in any terrain with ample obscuring plant life.</text>
+		</trait>
+		<trait>
+			<name>Regeneration</name>
+			<text>The wood woad regains 10 hit points at the start of its turn if it is in contact with the ground. If the wood woad takes fire damage, this trait doesn't function at the start of the wood woad's next turn. The wood woad dies only if it starts its turn with 0 hit points and doesn't regenerate.</text>
+		</trait>
+		<trait>
+			<name>Tree Stride</name>
+			<text>Once on each of its turns, the wood woad can use 10 feet of its movement to step magically into one living tree within 5 feet of it and emerge from a second living tree within 60 feet of it that it can see, appearing in an unoccupied space within 5 feet of the second tree. Both trees must be Large or bigger.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The wood woad makes two attacks with its club.</text>
+		</action>
+		<action>
+			<name>Club</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (4d4+4) bludgeoning damage.</text>
+			<attack>Club|7|4d4+4</attack>
+		</action>
+		<spells />
 	</monster>
 </compendium>

--- a/Bestiary/Dragon of Icespire Peak.xml
+++ b/Bestiary/Dragon of Icespire Peak.xml
@@ -1855,4 +1855,333 @@
 		</action>
 		<spells />
 	</monster>
+		<monster>
+		<name>Blackguard</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>any non-good alignment</alignment>
+		<ac>18 (plate)</ac>
+		<hp>153 (18d8+72)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>11</dex>
+		<con>18</con>
+		<int>11</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wis +5, Cha +5</save>
+		<skill>Athletics +7, Deception +5, Intimidation +5</skill>
+		<resist />
+		<vulnerable />
+		<immune />
+		<conditionImmune />
+		<senses />
+		<passive>12</passive>
+		<languages>any one language (usually Common)</languages>
+		<cr>8</cr>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The blackguard is a 10th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 33, +5 to hit with spell attacks). It has the following paladin spells prepared:</text>
+			<text>1st level (4 slots): command, protection from evil and good, thunderous smite</text>
+			<text>2nd level (3 slots): branding smite, find steed</text>
+			<text>3rd level (2 slots): blinding smite, dispel magic</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The blackguard makes three attacks with its glaive or its shortbow.</text>
+		</action>
+		<action>
+			<name>Glaive</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 9 (1d10+4) slashing damage.</text>
+			<attack>Glaive|7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 5 (1d6+2) piercing damage.</text>
+			<attack>Shortbow|3|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dreadful Aspect (Recharges after a Short or Long Rest)</name>
+			<text>The blackguard exudes magical menace. Each enemy within 30 feet of the blackguard must succeed on a DC 13 Wisdom saving throw or be frightened for 1 minute. If a frightened target ends its turn more than 30 feet away from the blackguard, the tar get can repeat the saving throw, ending the effect on itself on a success.</text>
+		</action>
+		<spells>Command, Protection from Evil and Good, Thunderous Smite, Branding Smite, Find Steed, Blinding Smite, Dispel Magic</spells>
+		<slots>4,3,2,0,0,0,0,0,0</slots>
+	</monster>
+	<monster>
+		<name>Boneclaw</name>
+		<size>L</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>chaotic evil</alignment>
+		<ac>16 (natural armor)</ac>
+		<hp>127 (17d10+34)</hp>
+		<speed>40 ft.</speed>
+		<str>19</str>
+		<dex>16</dex>
+		<con>15</con>
+		<int>13</int>
+		<wis>15</wis>
+		<cha>9</cha>
+		<save>Dex +7, Con +6, Wis +6</save>
+		<skill>Perception +6, Stealth +7</skill>
+		<resist>cold, necrotic; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune />
+		<conditionImmune>charmed, exhaustion, frightened, paralyzed, poisoned</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>16</passive>
+		<languages>Common plus the main language of its master</languages>
+		<cr>12</cr>
+		<trait>
+			<name>Undead Nature</name>
+			<text>A boneclaw doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Rejuvenation</name>
+			<text>While its master lives, a destroyed boneclaw gains a new body in 1d10 hours, with all its hit points. The new body appears within 1 mile of the boneclaw's master.</text>
+		</trait>
+		<trait>
+			<name>Shadow Stealth</name>
+			<text>While in dim light or darkness, the boneclaw can take the Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The boneclaw makes two claw attacks.</text>
+		</action>
+		<action>
+			<name>Piercing Claw</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 15 ft., one target. Hit: 20 (3d10 + 4) piercing damage. If the target is a creature, the boneclaw can pull the target up to 10 feet toward itself, and the target is grappled (escape DC 14). The boneclaw has two claws. While a claw grapples a target, the claw can attack only that target.</text>
+			<text />
+			<text>Grappled:</text>
+			<text>• A grappled creature's speed becomes 0, and it can't benefit from any bonus to its speed.</text>
+			<text />
+			<text>• The condition ends if the grappler is incapacitated.</text>
+			<text />
+			<text>• The condition also ends if an effect removes the grappled creature from the reach of the grappler or grappling effect, such as when a creature is hurled away by the thunderwave spell.</text>
+			<attack>Piercing Claw|8|3d10+4</attack>
+		</action>
+		<action>
+			<name>Shadow Jump</name>
+			<text>If the boneclaw is in dim light or darkness, each creature of the boneclaw's choice within 5 feet of it must succeed on a DC 14 Constitution saving throw or take 34 (5d12 + 2) necrotic damage.</text>
+			<text>The boneclaw then magically teleports up to 60 feet to an unoccupied space it can see. It can bring one creature it's grappling, teleporting that creature to an unoccupied space it can see within 5 feet of its destination. The destination spaces of this teleportation must be in dim light or darkness.</text>
+		</action>
+		<reaction>
+			<name>Deadly Reach</name>
+			<text>In response to a visible enemy moving into its reach, the boneclaw makes one claw attack against that enemy. If the attack hits, the boneclaw can make a second claw attack against the target.</text>
+			<attack />
+		</reaction>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Eidolon</name>
+		<size>M</size>
+		<type>undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>any alignment</alignment>
+		<ac>9</ac>
+		<hp>63 (18d8_18)</hp>
+		<speed>0 ft., fly 40 ft. (hover)</speed>
+		<str>7</str>
+		<dex>8</dex>
+		<con>9</con>
+		<int>14</int>
+		<wis>19</wis>
+		<cha>16</cha>
+		<save>Wis +8</save>
+		<skill>Perception +8</skill>
+		<resist>acid, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune>cold, necrotic, poison</immune>
+		<conditionImmune>charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>18</passive>
+		<languages>the languages it knew in life</languages>
+		<cr>12</cr>
+		<trait>
+			<name>Undead Nature</name>
+			<text>An eidolon doesn't require air, food, drink, or sleep.</text>
+		</trait>
+		<trait>
+			<name>Incorporeal Movement</name>
+			<text>The eidolon can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object other than a sacred statue.</text>
+		</trait>
+		<trait>
+			<name>Sacred Animation (Recharge 5-6)</name>
+			<text>When the eidolon moves into a space occupied by a sacred statue, the eidolon can disappear, causing the statue to become a creature under the eidolon's control. The eidolon uses the sacred statue's statistics in place of its own.</text>
+		</trait>
+		<trait>
+			<name>Turn Resistance</name>
+			<text>The eidolon has advantage on saving throws against any effect that turns undead.</text>
+		</trait>
+		<action>
+			<name>Divine Dread</name>
+			<text>Each creature within 60 feet of the eidolon that can see it must succeed on a DC 15 Wisdom saving throw or be frightened of it for 1 minute. While frightened in this way, the creature must take the Dash action and move away from the eidolon by the safest available route at the start of each of its turns, unless there is nowhere for it to move, in which case the creature also becomes stunned until it can move again. A frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to any eidolon's Divine Dread for the next 24 hours.</text>
+			<text />
+			<text>Frightened:</text>
+			<text>• A frightened creature has disadvantage on ability checks and attack rolls while the source of its fear is within line of sight.</text>
+			<text />
+			<text>• The creature can't willingly move closer to the source of its fear.</text>
+			<text />
+			<text>Stunned:</text>
+			<text>• A stunned creature is incapacitated, meaning it can't take actions or reactions, can't move, and can speak only falteringly.</text>
+			<text />
+			<text>• The creature automatically fails Strength and Dexterity saving throws.</text>
+			<text />
+			<text>• Attack rolls against the creature have advantage.</text>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+	<monster>
+		<name>Half-Blue Dragon Gladiator</name>
+		<size>M</size>
+		<type>humanoid (any race)</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>any alignment</alignment>
+		<ac>16 (studded leather, shield)</ac>
+		<hp>112 (15d8 + 45)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>15</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>15</cha>
+		<save>Str +7, Dex +5, Con +6</save>
+		<skill>Athletics +10, Intimidation +5</skill>
+		<resist>lightning</resist>
+		<senses></senses>
+		<passive>11</passive>
+		<languages>Draconic, Any one language (usually Common)</languages>
+		<cr>5</cr>
+		<trait>
+			<name>Brave</name>
+			<text>The gladiator has advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Brute</name>
+			<text>A melee weapon deals one extra die of its damage when the gladiator hits with it (included in the attack).</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The gladiator makes three melee attacks or two ranged attacks.</text>
+		</action>
+		<action>
+			<name>Spear</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack.</text>
+			<attack>Spear (1H)|7|2d6+4</attack>
+			<attack>Spear (2H)|7|2d8+4</attack>
+		</action>
+		<action>
+			<name>Shield Bash</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 9 (2d4 + 4) bludgeoning damage. If the target is a Medium or smaller creature, it must succeed on a DC 15 Strength saving throw or be knocked prone.</text>
+			<attack>Shield Bash|7|2d4+4</attack>
+		</action>
+		<action>
+			<name>Lightning Breath (Recharge 5-6)</name>
+			<text>The half-blue dragon exhales lightning in a 30-­foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one.</text>
+			<attack>Lightning Breath||4d10</attack>
+		</action>
+		<reaction>
+			<name>Parry</name>
+			<text>The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon.</text>
+		</reaction>
+	</monster>
+		<monster>
+		<name>Sacred Statue</name>
+		<size>L</size>
+		<type>construct</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>as the eidolon's alignment</alignment>
+		<ac>19 (natural armor)</ac>
+		<hp>95 (10d10+40)</hp>
+		<speed>25 ft.</speed>
+		<str>19</str>
+		<dex>8</dex>
+		<con>19</con>
+		<int>14</int>
+		<wis>19</wis>
+		<cha>16</cha>
+		<save>Wis +8</save>
+		<skill />
+		<resist>acid, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
+		<vulnerable />
+		<immune>cold, necrotic, poison</immune>
+		<conditionImmune>charmed, exhaustion, frightened, paralyzed, petrified, poisoned</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>14</passive>
+		<languages>the languages the eidolon knew in life</languages>
+		<cr>12</cr>
+		<trait>
+			<name>False Appearance</name>
+			<text>While the statue remains motionless, it is indistinguishable from a normal statue.</text>
+		</trait>
+		<trait>
+			<name>Ghostly Inhabitant</name>
+			<text>The eidolon that enters the sacred statue remains inside it until the statue drops to 0 hit points, the eidolon uses a bonus action to move out of the statue, or the eidolon is turned or forced out by an effect such as the dispel evil and good spell. When the eidolon leaves the statue, it appears in an unoccupied space within 5 feet of the statue.</text>
+		</trait>
+		<trait>
+			<name>Inert</name>
+			<text>When not inhabited by an eidolon, the statue is an object.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The statue makes two slam attacks.</text>
+		</action>
+		<action>
+			<name>Slam</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 43 (6d12 + 4) bludgeoning damage.</text>
+			<attack>Slam|8|6d12+4</attack>
+		</action>
+		<action>
+			<name>Rock</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 60 ft./240 ft., one target. Hit: 37 (6d10 + 4) bludgeoning damage.</text>
+			<attack>Rock|8|6d10+4</attack>
+		</action>
+		<spells />
+		<slots />
+	</monster>
+		<monster>
+		<name>Skeletal Swarm</name>
+		<size>L</size>
+		<type>swarm of medium undead</type>
+		<description>Source: Dragon of Icespire Peak</description>
+		<alignment>lawful evil</alignment>
+		<ac>13 (armor scraps)</ac>
+		<hp>60 (8d10 + 16)</hp>
+		<speed>30 ft.</speed>
+		<str>12</str>
+		<dex>14</dex>
+		<con>15</con>
+		<int>6</int>
+		<wis>8</wis>
+		<cha>5</cha>
+		<save />
+		<skill />
+		<vulnerable>bludgeoning</vulnerable>
+		<resist>slashing, piercing</resist>
+		<immune>poison</immune>
+		<conditionImmune>charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone, restrained, stunned</conditionImmune>
+		<senses>darkvision 60 ft.</senses>
+		<passive>9</passive>
+		<languages>—</languages>
+		<cr>2</cr>
+		<trait>
+			<name>Deafening Clatter</name>
+			<text>Creatures are deafened while in the swarm's space.</text>
+		</trait>
+		<trait>
+			<name>Swarm</name>
+			<text>The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Small humanoid. The swarm can't regain hit points or gain temporary hit points.</text>
+		</trait>
+		<action>
+			<name>Slash</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 0 ft., one target in the swarm's space. Hit: 11 (2d8 + 2) slashing damage, or 6 (1d8 + 2) slashing damage if the swarm has half of its hit points or fewer.</text>
+			<attack>Slash|4|2d8+2</attack>
+			<attack>Slash (under 1/2hp)|4|1d8+2</attack>
+		</action>
+	</monster>
+
 </compendium>

--- a/Bestiary/Sidekicks.xml
+++ b/Bestiary/Sidekicks.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <compendium version="5">
 	<!--Sidekicks-->
+	<!--Generic-->
 	<monster>
 		<name>Sidekick: Warrior (Attacker) 01</name>
 		<type>humanoid, sidekick</type>
@@ -1775,9 +1776,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light</text>
-			<text></text>
+			<text/>
 			<text>1st level (2 slots): sleep</text>
 		</trait>
 		<slots>2,0,0,0,0,0,0,0,0,</slots>
@@ -1809,9 +1810,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light</text>
-			<text></text>
+			<text/>
 			<text>1st level (2 slots): sleep, burning hands</text>
 		</trait>
 		<slots>2,0,0,0,0,0,0,0,0,</slots>
@@ -1843,9 +1844,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light</text>
-			<text></text>
+			<text/>
 			<text>1st level (3 slots): sleep, burning hands, shield</text>
 		</trait>
 		<slots>3,0,0,0,0,0,0,0,0,</slots>
@@ -1877,9 +1878,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand</text>
-			<text></text>
+			<text/>
 			<text>1st level (3 slots): sleep, burning hands, shield</text>
 		</trait>
 		<slots>3,0,0,0,0,0,0,0,0,</slots>
@@ -1911,11 +1912,11 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (2 slots): invisibility</text>
 		</trait>
 		<slots>4,2,0,0,0,0,0,0,0,</slots>
@@ -1951,11 +1952,11 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (2 slots): invisibility</text>
 		</trait>
 		<slots>4,2,0,0,0,0,0,0,0,</slots>
@@ -1991,15 +1992,15 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (1 slot): wall of fire</text>
 		</trait>
 		<slots>4,3,3,1,0,0,0,0,0,</slots>
@@ -2035,15 +2036,15 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (2 slots): wall of fire, polymorph</text>
 		</trait>
 		<slots>4,3,3,2,0,0,0,0,0,</slots>
@@ -2079,17 +2080,17 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (1 slot): cone of cold</text>
 		</trait>
 		<slots>4,3,3,3,1,0,0,0,0,</slots>
@@ -2129,17 +2130,17 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (2 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster</text>
 		</trait>
 		<slots>4,3,3,3,2,0,0,0,0,</slots>
@@ -2179,19 +2180,19 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning</text>
 		</trait>
 		<slots>4,3,3,3,2,1,0,0,0,</slots>
@@ -2231,19 +2232,19 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning</text>
 		</trait>
 		<slots>4,3,3,3,2,1,0,0,0,</slots>
@@ -2275,9 +2276,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame</text>
-			<text></text>
+			<text/>
 			<text>1st level (2 slots): cure wounds</text>
 		</trait>
 		<slots>2,0,0,0,0,0,0,0,0,</slots>
@@ -2309,9 +2310,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame</text>
-			<text></text>
+			<text/>
 			<text>1st level (2 slots): cure wounds, bless</text>
 		</trait>
 		<slots>2,0,0,0,0,0,0,0,0,</slots>
@@ -2343,9 +2344,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame</text>
-			<text></text>
+			<text/>
 			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
 		</trait>
 		<slots>3,0,0,0,0,0,0,0,0,</slots>
@@ -2377,9 +2378,9 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
-			<text></text>
+			<text/>
 			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
 		</trait>
 		<slots>3,0,0,0,0,0,0,0,0,</slots>
@@ -2411,11 +2412,11 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (2 slots): aid</text>
 		</trait>
 		<slots>4,2,0,0,0,0,0,0,0,</slots>
@@ -2451,11 +2452,11 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (2 slots): aid</text>
 		</trait>
 		<slots>4,2,0,0,0,0,0,0,0,</slots>
@@ -2491,15 +2492,15 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (1 slot): death ward</text>
 		</trait>
 		<slots>4,3,3,1,0,0,0,0,0,</slots>
@@ -2535,15 +2536,15 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (2 slots): death ward, banishment</text>
 		</trait>
 		<slots>4,3,3,2,0,0,0,0,0,</slots>
@@ -2579,17 +2580,17 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (1 slot): greater restoration</text>
 		</trait>
 		<slots>4,3,3,3,1,0,0,0,0,</slots>
@@ -2629,17 +2630,17 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (2 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
 		</trait>
 		<slots>4,3,3,3,2,0,0,0,0,</slots>
@@ -2679,19 +2680,19 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal</text>
 		</trait>
 		<slots>4,3,3,3,2,1,0,0,0,</slots>
@@ -2731,19 +2732,19 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal</text>
 		</trait>
 		<slots>4,3,3,3,2,1,0,0,0,</slots>
@@ -2755,8 +2756,9699 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</monster>
-
+	<!--Specific-->
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>15/15 (2d8 + 6)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>15/15 (2d8 + 6)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>22/22 (3d8 + 9)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>22/22 (3d8 + 9)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>30/30 (4d8 + 12)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>30/30 (4d8 + 12)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>37/37 (5d8 + 15)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>37/37 (5d8 + 15)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+6|1d8+4</attack>
+			<attack>2 hand|+6|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (6d8 + 18)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (6d8 + 18)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>52/52 (7d8 + 21)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>52/52 (7d8 + 21)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>60/60 (8d8 + 24)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>60/60 (8d8 + 24)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>67/67 (9d8 + 27)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>67/67 (9d8 + 27)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+8|1d8+5</attack>
+			<attack>2 hand|+8|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>75/75 (10d8 + 30)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>75/75 (10d8 + 30)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>82/82 (11d8 + 33)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>82/82 (11d8 + 33)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>90/90 (12d8 + 36)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>90/90 (12d8 + 36)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (13d8 + 39)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+9|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (13d8 + 39)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+8|2d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>17</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Acrobatics +4, Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +5, Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +5, Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+4|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +5, Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +5, Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+4|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +6, Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +6, Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+5|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +6, Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Acrobatics +6, Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+5|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Acrobatics +7, Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+6|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+6|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>15</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+7|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+7|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6, Performance +4, Persuasion +4, Sleight of Hand +6, Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9, Performance +5, Persuasion +5, Sleight of Hand +6, Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12, Performance +6, Persuasion +6, Sleight of Hand +8, Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +8, Persuasion +8, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6, Performance +4, Persuasion +4, Sleight of Hand +6, Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9, Performance +5, Persuasion +5, Sleight of Hand +6, Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12, Performance +6, Persuasion +6, Sleight of Hand +8, Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +8, Persuasion +8, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6, Performance +4, Persuasion +4, Sleight of Hand +6, Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9, Performance +5, Persuasion +5, Sleight of Hand +6, Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12, Performance +6, Persuasion +6, Sleight of Hand +8, Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13, Performance +8, Persuasion +8, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>16</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text/>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>17</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text/>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
 	<!--Extrapolated Leveling-->
+	<!--Generic-->
 	<monster>
 		<name>Sidekick: Warrior (Attacker) 13</name>
 		<type>humanoid, sidekick</type>
@@ -4240,21 +13932,21 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): delayed blast fireball</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,0,0,</slots>
@@ -4298,21 +13990,21 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): delayed blast fireball</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,0,0,</slots>
@@ -4356,23 +14048,23 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): delayed blast fireball</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): incendiary cloud</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,1,0,</slots>
@@ -4416,23 +14108,23 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning, circle of death</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): delayed blast fireball</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): incendiary cloud</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,1,0,</slots>
@@ -4476,25 +14168,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning, circle of death</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): delayed blast fireball</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): incendiary cloud</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): meteor swarm</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,1,1,</slots>
@@ -4542,25 +14234,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): chain lightning, circle of death</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): incendiary cloud</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): meteor swarm</text>
 		</trait>
 		<slots>4,3,3,3,3,1,1,1,1,</slots>
@@ -4608,25 +14300,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (2 slots): chain lightning, circle of death</text>
-			<text></text>
+			<text/>
 			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): meteor swarm</text>
 		</trait>
 		<slots>4,3,3,3,3,2,2,1,1,</slots>
@@ -4678,25 +14370,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): sleep, burning hands, shield</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): invisibility, flaming sphere</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): fireball, fly</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): wall of fire, polymorph</text>
-			<text></text>
+			<text/>
 			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
-			<text></text>
+			<text/>
 			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
-			<text></text>
+			<text/>
 			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): meteor swarm, power word kill</text>
 		</trait>
 		<slots>4,3,3,3,3,2,2,1,1,</slots>
@@ -4736,21 +14428,21 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): regenerate</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,0,0,</slots>
@@ -4794,21 +14486,21 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): regenerate</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,0,0,</slots>
@@ -4852,23 +14544,23 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): regenerate</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): holy aura</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,1,0,</slots>
@@ -4912,23 +14604,23 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal, heroes' feast</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): regenerate</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): holy aura</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,1,0,</slots>
@@ -4972,25 +14664,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal, heroes' feast</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): regenerate</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): holy aura</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): mass heal</text>
 		</trait>
 		<slots>4,3,3,3,2,1,1,1,1,</slots>
@@ -5038,25 +14730,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (1 slot): heal, heroes' feast</text>
-			<text></text>
+			<text/>
 			<text>7th level (1 slot): regenerate, resurrection</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): holy aura</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): mass heal</text>
 		</trait>
 		<slots>4,3,3,3,3,1,1,1,1,</slots>
@@ -5104,25 +14796,25 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (2 slots): heal, heroes' feast</text>
-			<text></text>
+			<text/>
 			<text>7th level (2 slots): regenerate, resurrection</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): holy aura, antimagic field</text>
-			<text></text>
+			<text/>
 			<text>9th level (1 slot): mass heal</text>
 		</trait>
 		<slots>4,3,3,3,3,2,2,1,1,</slots>
@@ -5174,25 +14866,8331 @@
 		<trait>
 			<name>Spellcasting</name>
 			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
-			<text></text>
+			<text/>
 			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
-			<text></text>
+			<text/>
 			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
-			<text></text>
+			<text/>
 			<text>2nd level (3 slots): aid, lesser restoration</text>
-			<text></text>
+			<text/>
 			<text>3rd level (3 slots): protection from energy, revivify</text>
-			<text></text>
+			<text/>
 			<text>4th level (3 slots): death ward, banishment</text>
-			<text></text>
+			<text/>
 			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
-			<text></text>
+			<text/>
 			<text>6th level (2 slots): heal, heroes' feast</text>
-			<text></text>
+			<text/>
 			<text>7th level (2 slots): regenerate, resurrection</text>
-			<text></text>
+			<text/>
 			<text>8th level (1 slot): holy aura, antimagic field</text>
-			<text></text>
+			<text/>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<!--Specific-->
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>105/105 (14d8 + 42)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>105/105 (14d8 + 42)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>112/112 (15d8 + 45)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>112/112 (15d8 + 45)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>120/120 (16d8 + 48)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>120/120 (16d8 + 48)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>127/127 (17d8 + 51)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+12|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>127/127 (17d8 + 51)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+10|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>135/135 (18d8 + 54)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +9</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>135/135 (18d8 + 54)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +9</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>142/142 (19d8 + 57)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +9</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>142/142 (19d8 + 57)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +9</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>170/170 (20d8 + 80)</hp>
+		<speed>25 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>18</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +10</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>170/170 (20d8 + 80)</hp>
+		<speed>25 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>18</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +10</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Attacker) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>178/178 (21d8 + 84)</hp>
+		<speed>25 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>18</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +10</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Ruby Hammerwhacker (Defender) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>178/178 (21d8 + 84)</hp>
+		<speed>25 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>18</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +10</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. Donnabella can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. Donnabella can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella Fiasco (Healer) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Donnabella can choose one 3rd level spell. Donnabella can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. Donnabella can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text/>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. She can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. She can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Donnabella (Mage) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Donnabella can choose one 3rd level spell. She can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. She can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text/>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +8, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+9|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +8, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +9, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +9, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+8|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +9, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +9, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+8|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +10, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Acrobatics +10, Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+9|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+12|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+10|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+12|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+10|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>150/150 (20d8+60)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>150/150 (20d8+60)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Attacker) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>156/156 (21d8+62)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Inverna Nightbreeze (Defender) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>156/156 (21d8+62)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>11</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Acrobatics +11, Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+9|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+7|1d6+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+10|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+10|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+12|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+12|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>150/150 (20d8+60)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+13|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>150/150 (20d8+60)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Attacker) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>156/156 (21d8+62)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack four times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+13|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Quinn Hightopple (Defender) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>156/156 (21d8+62)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>11</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack four times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15, Performance +10, Persuasion +10, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Galandro Luna 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>The expert has an uncanny knack for succeeding when they need to. If their attack misses a target within range, they can turn the miss into a hit. Alternatively, if they fail an ability check, they can treat the d20 roll as a 20.</text>
+			<text>The expert can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15, Performance +10, Persuasion +10, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Pete is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Pete is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Pickled Pete 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>Pete has an uncanny knack for succeeding when they need to. If his attack misses a target within range, he can turn the miss into a hit. Alternatively, if he fail an ability check, he can treat the d20 roll as a 20.</text>
+			<text>Pete can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>Pete is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15, Performance +10, Persuasion +10, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Talon is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Talon is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Talon Thornwild 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>Talon has an uncanny knack for succeeding when they need to. If his attack misses a target within range, he can turn the miss into a hit. Alternatively, if he fail an ability check, he can treat the d20 roll as a 20.</text>
+			<text>Talon can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>Talon is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12, Investigation +12, Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Mage) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12, Investigation +12, Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Nib can choose one 3rd level spell. Nib can cast thers spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text/>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Nib Addlespur (Healer) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Nib can choose one 3rd level spell. Nib can cast thers spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text/>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>15</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>15</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>15</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +12, Investigation +12, Religion +12</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text/>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Mage) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +12, Investigation +12, Religion +12</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Shajan can choose one 3rd level spell. Shajan can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text/>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text/>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text/>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text/>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text/>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text/>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text/>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text/>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text/>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text/>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Shajan Kwan (Healer) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Shajan can choose one 3rd level spell. Shajan can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text/>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text/>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text/>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text/>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text/>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text/>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text/>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text/>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text/>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text/>
 			<text>9th level (1 slot): mass heal, true resurrection</text>
 		</trait>
 		<slots>4,3,3,3,3,2,2,1,1,</slots>

--- a/Bestiary/Sidekicks.xml
+++ b/Bestiary/Sidekicks.xml
@@ -4388,7 +4388,7 @@
 		<name>Sidekick: Spellcaster (Mage) 16</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -4448,7 +4448,7 @@
 		<name>Sidekick: Spellcaster (Mage) 17</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -4510,7 +4510,7 @@
 		<name>Sidekick: Spellcaster (Mage) 18</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -4576,7 +4576,7 @@
 		<name>Sidekick: Spellcaster (Mage) 19</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -4642,7 +4642,7 @@
 		<name>Sidekick: Spellcaster (Mage) 20</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -4884,7 +4884,7 @@
 		<name>Sidekick: Spellcaster (Healer) 16</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -4944,7 +4944,7 @@
 		<name>Sidekick: Spellcaster (Healer) 17</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -5006,7 +5006,7 @@
 		<name>Sidekick: Spellcaster (Healer) 18</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -5072,7 +5072,7 @@
 		<name>Sidekick: Spellcaster (Healer) 19</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
@@ -5138,7 +5138,7 @@
 		<name>Sidekick: Spellcaster (Healer) 20</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>

--- a/Bestiary/Sidekicks.xml
+++ b/Bestiary/Sidekicks.xml
@@ -1,0 +1,5207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<compendium version="5">
+	<!--Sidekicks-->
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +4, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +4</save>
+		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +6, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +5</save>
+		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +8, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +6</save>
+		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>15</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +4</save>
+		<skill>Acrobatics +4, Performance +4, Persuasion +4, Sleight of Hand +4, Stealth +4</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>|+4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>15</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +4</save>
+		<skill>Acrobatics +4, Performance +4, Persuasion +4, Sleight of Hand +4, Stealth +4</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>|+4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>15</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +4</save>
+		<skill>Acrobatics +4, Performance +4, Persuasion +4, Sleight of Hand +4, Stealth +4</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>|+4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>17</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +5</save>
+		<skill>Acrobatics +5, Performance +4, Persuasion +4, Sleight of Hand +5, Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>17</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +6</save>
+		<skill>Acrobatics +6, Performance +5, Persuasion +5, Sleight of Hand +6, Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>17</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +6</save>
+		<skill>Acrobatics +6, Performance +5, Persuasion +5, Sleight of Hand +6, Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>16</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +6</save>
+		<skill>Acrobatics +9, Performance +5, Persuasion +5, Sleight of Hand +6, Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>18</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +7</save>
+		<skill>Acrobatics +10, Performance +5, Persuasion +5, Sleight of Hand +7, Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>18</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +8</save>
+		<skill>Acrobatics +12, Performance +6, Persuasion +6, Sleight of Hand +8, Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +8 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dex +9</save>
+		<skill>Acrobatics +13, Performance +6, Persuasion +6, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dex +9</save>
+		<skill>Acrobatics +13, Performance +7, Persuasion +7, Sleight of Hand +9, Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>16</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wis +5</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wis +5</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +9, Investigation +9, Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 01</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 02</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 03</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wis +4</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 04</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wis +5</save>
+		<skill>Arcana +4, Investigation +4, Religion +4</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 05</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 06</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 07</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wis +6</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 08</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wis +7</save>
+		<skill>Arcana +5, Investigation +5, Religion +5</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 09</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wis +8</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wis +8</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wis +8</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wis +9</save>
+		<skill>Arcana +6, Investigation +6, Religion +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</monster>
+
+	<!--Extrapolated Leveling-->
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+9|1d8+2</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +7</save>
+		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Attacker) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack four times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Warrior (Defender) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Con +8</save>
+		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack four times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +8, Persuasion +8, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16, Performance +8, Persuasion +8, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16, Performance +8, Persuasion +8, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15, Performance +9, Persuasion +9, Sleight of Hand +10, Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>18</cha>
+		<save>Dexterity +11, Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +10, Persuasion +10, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>18</cha>
+		<save>Dexterity +11, Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +10, Persuasion +10, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>20</cha>
+		<save>Dexterity +11, Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Expert 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>20</cha>
+		<save>Dexterity +11, Wisdom +6</save>
+		<skill>Acrobatics +17, Performance +11, Persuasion +11, Sleight of Hand +11, Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>The expert has an uncanny knack for succeeding when they need to. If their attack misses a target within range, they can turn the miss into a hit. Alternatively, if they fail an ability check, they can treat the d20 roll as a 20.</text>
+			<text>The expert can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10, Investigation +10, Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11, Investigation +11, Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12, Investigation +12, Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Mage) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12, Investigation +12, Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>The spellcaster can choose one 3rd level spell. The spellcaster can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7, Investigation +7, Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+	<monster>
+		<name>Sidekick: Spellcaster (Healer) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8, Investigation +8, Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>The spellcaster can choose one 3rd level spell. The spellcaster can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</monster>
+</compendium>

--- a/Bestiary/Sidekicks.xml
+++ b/Bestiary/Sidekicks.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <compendium version="5">
 	<!--Sidekicks-->
+	
 	<!--Generic-->
 	<monster>
 		<name>Sidekick: Warrior (Attacker) 01</name>
@@ -2756,13 +2757,14 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</monster>
+
 	<!--Specific-->
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>15/15 (2d8 + 6)</hp>
+		<hp>15 (2d8 + 6)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -2773,6 +2775,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -2801,10 +2804,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>15/15 (2d8 + 6)</hp>
+		<hp>15 (2d8 + 6)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -2815,6 +2818,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -2843,10 +2847,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>22/22 (3d8 + 9)</hp>
+		<hp>22 (3d8 + 9)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -2857,6 +2861,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -2890,10 +2895,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>22/22 (3d8 + 9)</hp>
+		<hp>22 (3d8 + 9)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -2904,6 +2909,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -2937,10 +2943,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>30/30 (4d8 + 12)</hp>
+		<hp>30 (4d8 + 12)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -2951,6 +2957,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -2988,10 +2995,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>30/30 (4d8 + 12)</hp>
+		<hp>30 (4d8 + 12)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -3002,6 +3009,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +5, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3039,10 +3047,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>37/37 (5d8 + 15)</hp>
+		<hp>37 (5d8 + 15)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>19</str>
@@ -3053,6 +3061,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3090,10 +3099,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>37/37 (5d8 + 15)</hp>
+		<hp>37 (5d8 + 15)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>19</str>
@@ -3104,6 +3113,7 @@
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6, Perception +3, Survival +3</skill>
+		<resist>poison</resist>
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3141,10 +3151,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (6d8 + 18)</hp>
+		<hp>45 (6d8 + 18)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>19</str>
@@ -3155,6 +3165,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3192,10 +3203,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (6d8 + 18)</hp>
+		<hp>45 (6d8 + 18)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>19</str>
@@ -3206,6 +3217,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3243,10 +3255,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>52/52 (7d8 + 21)</hp>
+		<hp>52 (7d8 + 21)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>19</str>
@@ -3257,6 +3269,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3298,10 +3311,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>52/52 (7d8 + 21)</hp>
+		<hp>52 (7d8 + 21)</hp>
 		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>19</str>
@@ -3312,6 +3325,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3353,10 +3367,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>60/60 (8d8 + 24)</hp>
+		<hp>60 (8d8 + 24)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -3367,6 +3381,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3412,10 +3427,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>60/60 (8d8 + 24)</hp>
+		<hp>60 (8d8 + 24)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -3426,6 +3441,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +7, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3471,10 +3487,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>67/67 (9d8 + 27)</hp>
+		<hp>67 (9d8 + 27)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3485,6 +3501,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3530,10 +3547,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>67/67 (9d8 + 27)</hp>
+		<hp>67 (9d8 + 27)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3544,6 +3561,7 @@
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8, Perception +4, Survival +4</skill>
+		<resist>poison</resist>
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3589,10 +3607,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>75/75 (10d8 + 30)</hp>
+		<hp>75 (10d8 + 30)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3603,6 +3621,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3652,10 +3671,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>75/75 (10d8 + 30)</hp>
+		<hp>75 (10d8 + 30)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3666,6 +3685,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3715,10 +3735,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>82/82 (11d8 + 33)</hp>
+		<hp>82 (11d8 + 33)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3729,6 +3749,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3782,10 +3803,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>82/82 (11d8 + 33)</hp>
+		<hp>82 (11d8 + 33)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3796,6 +3817,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3849,10 +3871,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>90/90 (12d8 + 36)</hp>
+		<hp>90 (12d8 + 36)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3863,6 +3885,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3916,10 +3939,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>90/90 (12d8 + 36)</hp>
+		<hp>90 (12d8 + 36)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3930,6 +3953,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -3983,10 +4007,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (13d8 + 39)</hp>
+		<hp>97 (13d8 + 39)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -3997,6 +4021,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -4050,10 +4075,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (13d8 + 39)</hp>
+		<hp>97 (13d8 + 39)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -4064,6 +4089,7 @@
 		<cha>10</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +9, Perception +5, Survival +5</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -4117,10 +4143,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>9/9 (2d8)</hp>
+		<hp>9 (2d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4152,10 +4178,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>13/13 (3d8)</hp>
+		<hp>13 (3d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4187,10 +4213,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>18/18 (4d8)</hp>
+		<hp>18 (4d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4222,10 +4248,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>22/22 (5d8)</hp>
+		<hp>22 (5d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4257,10 +4283,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>27/27 (6d8)</hp>
+		<hp>27 (6d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4294,10 +4320,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>31/31 (7d8)</hp>
+		<hp>31 (7d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4335,10 +4361,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>36/36 (8d8)</hp>
+		<hp>36 (8d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4380,10 +4406,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>40/40 (9d8)</hp>
+		<hp>40 (9d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4425,10 +4451,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>45/45 (10d8)</hp>
+		<hp>45 (10d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4472,10 +4498,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>49/49 (11d8)</hp>
+		<hp>49 (11d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4523,10 +4549,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>54/54 (12d8)</hp>
+		<hp>54 (12d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4576,10 +4602,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>58/58 (13d8)</hp>
+		<hp>58 (13d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -4629,10 +4655,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>9/9 (2d8)</hp>
+		<hp>9 (2d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4664,10 +4690,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>13/13 (3d8)</hp>
+		<hp>13 (3d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4699,10 +4725,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>18/18 (4d8)</hp>
+		<hp>18 (4d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4734,10 +4760,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>22/22 (5d8)</hp>
+		<hp>22 (5d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4769,10 +4795,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>27/27 (6d8)</hp>
+		<hp>27 (6d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4806,10 +4832,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>31/31 (7d8)</hp>
+		<hp>31 (7d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4847,10 +4873,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>36/36 (8d8)</hp>
+		<hp>36 (8d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4892,10 +4918,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>40/40 (9d8)</hp>
+		<hp>40 (9d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4937,10 +4963,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>45/45 (10d8)</hp>
+		<hp>45 (10d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -4984,10 +5010,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>49/49 (11d8)</hp>
+		<hp>49 (11d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -5035,10 +5061,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>54/54 (12d8)</hp>
+		<hp>54 (12d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -5088,10 +5114,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>58/58 (13d8)</hp>
+		<hp>58 (13d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -5141,10 +5167,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>13/13 (2d8+4)</hp>
+		<hp>13 (2d8+4)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -5187,10 +5213,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>13/13 (2d8+4)</hp>
+		<hp>13 (2d8+4)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -5233,10 +5259,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>19/19 (3d8 + 6)</hp>
+		<hp>19 (3d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -5284,10 +5310,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>19/19 (3d8 + 6)</hp>
+		<hp>19 (3d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -5335,10 +5361,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>26/26 (4d8 + 8)</hp>
+		<hp>26 (4d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -5390,10 +5416,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>26/26 (4d8 + 8)</hp>
+		<hp>26 (4d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -5445,10 +5471,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>32/32 (5d8 + 10)</hp>
+		<hp>32 (5d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -5500,10 +5526,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>32/32 (5d8 + 10)</hp>
+		<hp>32 (5d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -5555,10 +5581,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>39/39 (6d8 + 12)</hp>
+		<hp>39 (6d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -5610,10 +5636,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>39/39 (6d8 + 12)</hp>
+		<hp>39 (6d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -5665,10 +5691,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (7d8 + 14)</hp>
+		<hp>45 (7d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -5724,10 +5750,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (7d8 + 14)</hp>
+		<hp>45 (7d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -5783,10 +5809,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>52/52 (8d8 + 16)</hp>
+		<hp>52 (8d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
@@ -5846,10 +5872,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>52/52 (8d8 + 16)</hp>
+		<hp>52 (8d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
@@ -5909,10 +5935,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>58/58 (9d8 + 18)</hp>
+		<hp>58 (9d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -5972,10 +5998,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>58/58 (9d8 + 18)</hp>
+		<hp>58 (9d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6035,10 +6061,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>65/65 (10d8 + 20)</hp>
+		<hp>65 (10d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6102,10 +6128,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>65/65 (10d8 + 20)</hp>
+		<hp>65 (10d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6169,10 +6195,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>71/71 (11d8 + 22)</hp>
+		<hp>71 (11d8 + 22)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6240,10 +6266,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>71/71 (11d8 + 22)</hp>
+		<hp>71 (11d8 + 22)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6311,10 +6337,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>78/78 (12d8 + 24)</hp>
+		<hp>78 (12d8 + 24)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6382,10 +6408,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>78/78 (12d8 + 24)</hp>
+		<hp>78 (12d8 + 24)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -6453,10 +6479,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>84/84 (13d8 + 26)</hp>
+		<hp>84 (13d8 + 26)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -6524,10 +6550,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>84/84 (13d8 + 26)</hp>
+		<hp>84 (13d8 + 26)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -6595,10 +6621,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>13/13 (2d8+4)</hp>
+		<hp>13 (2d8+4)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -6645,10 +6671,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>13/13 (2d8+4)</hp>
+		<hp>13 (2d8+4)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -6695,10 +6721,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>19/19 (3d8 + 6)</hp>
+		<hp>19 (3d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -6750,10 +6776,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>19/19 (3d8 + 6)</hp>
+		<hp>19 (3d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -6805,10 +6831,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>26/26 (4d8 + 8)</hp>
+		<hp>26 (4d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -6864,10 +6890,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>26/26 (4d8 + 8)</hp>
+		<hp>26 (4d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
@@ -6923,10 +6949,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>32/32 (5d8 + 10)</hp>
+		<hp>32 (5d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -6982,10 +7008,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>32/32 (5d8 + 10)</hp>
+		<hp>32 (5d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -7041,10 +7067,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>39/39 (6d8 + 12)</hp>
+		<hp>39 (6d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -7100,10 +7126,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>39/39 (6d8 + 12)</hp>
+		<hp>39 (6d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -7159,10 +7185,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (7d8 + 14)</hp>
+		<hp>45 (7d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -7222,10 +7248,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (7d8 + 14)</hp>
+		<hp>45 (7d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
@@ -7285,10 +7311,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>52/52 (8d8 + 16)</hp>
+		<hp>52 (8d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
@@ -7352,10 +7378,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>52/52 (8d8 + 16)</hp>
+		<hp>52 (8d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
@@ -7419,10 +7445,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>58/58 (9d8 + 18)</hp>
+		<hp>58 (9d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7486,10 +7512,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>58/58 (9d8 + 18)</hp>
+		<hp>58 (9d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7553,10 +7579,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>65/65 (10d8 + 20)</hp>
+		<hp>65 (10d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7624,10 +7650,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>65/65 (10d8 + 20)</hp>
+		<hp>65 (10d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7695,10 +7721,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>71/71 (11d8 + 22)</hp>
+		<hp>71 (11d8 + 22)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7770,10 +7796,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>71/71 (11d8 + 22)</hp>
+		<hp>71 (11d8 + 22)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7845,10 +7871,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>78/78 (12d8 + 24)</hp>
+		<hp>78 (12d8 + 24)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7920,10 +7946,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>78/78 (12d8 + 24)</hp>
+		<hp>78 (12d8 + 24)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
@@ -7995,10 +8021,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>84/84 (13d8 + 26)</hp>
+		<hp>84 (13d8 + 26)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -8070,10 +8096,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>84/84 (13d8 + 26)</hp>
+		<hp>84 (13d8 + 26)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -8145,10 +8171,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>11/11 (2d8 + 2)</hp>
+		<hp>11 (2d8 + 2)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8187,10 +8213,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>16/16 (3d8 + 3)</hp>
+		<hp>16 (3d8 + 3)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8233,10 +8259,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>22/22 (4d8 + 4)</hp>
+		<hp>22 (4d8 + 4)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8283,10 +8309,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>27/27 (5d8 + 5)</hp>
+		<hp>27 (5d8 + 5)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -8333,10 +8359,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>33/33 (6d8 + 6)</hp>
+		<hp>33 (6d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -8383,10 +8409,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>38/38 (7d8 + 7)</hp>
+		<hp>38 (7d8 + 7)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -8437,10 +8463,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>44/44 (8d8 + 8)</hp>
+		<hp>44 (8d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8491,10 +8517,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>49/49 (9d8 + 9)</hp>
+		<hp>49 (9d8 + 9)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -8545,10 +8571,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>55/55 (10d8 + 10)</hp>
+		<hp>55 (10d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -8599,10 +8625,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>60/60 (11d8 + 11)</hp>
+		<hp>60 (11d8 + 11)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -8653,10 +8679,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>66/66 (12d8 + 12)</hp>
+		<hp>66 (12d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -8711,10 +8737,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>71/71 (13d8 + 13)</hp>
+		<hp>71 (13d8 + 13)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -8769,10 +8795,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>11/11 (2d8 + 2)</hp>
+		<hp>11 (2d8 + 2)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8811,10 +8837,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>16/16 (3d8 + 3)</hp>
+		<hp>16 (3d8 + 3)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8857,10 +8883,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>22/22 (4d8 + 4)</hp>
+		<hp>22 (4d8 + 4)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -8907,10 +8933,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>27/27 (5d8 + 5)</hp>
+		<hp>27 (5d8 + 5)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -8957,10 +8983,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>33/33 (6d8 + 6)</hp>
+		<hp>33 (6d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9007,10 +9033,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>38/38 (7d8 + 7)</hp>
+		<hp>38 (7d8 + 7)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9061,10 +9087,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>44/44 (8d8 + 8)</hp>
+		<hp>44 (8d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -9115,10 +9141,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>49/49 (9d8 + 9)</hp>
+		<hp>49 (9d8 + 9)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9169,10 +9195,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>55/55 (10d8 + 10)</hp>
+		<hp>55 (10d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9223,10 +9249,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>60/60 (11d8 + 11)</hp>
+		<hp>60 (11d8 + 11)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -9277,10 +9303,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>66/66 (12d8 + 12)</hp>
+		<hp>66 (12d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -9335,10 +9361,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>71/71 (13d8 + 13)</hp>
+		<hp>71 (13d8 + 13)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -9393,10 +9419,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>11/11 (2d8 + 2)</hp>
+		<hp>11 (2d8 + 2)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -9435,10 +9461,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>16/16 (3d8 + 3)</hp>
+		<hp>16 (3d8 + 3)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -9481,10 +9507,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>22/22 (4d8 + 4)</hp>
+		<hp>22 (4d8 + 4)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -9531,10 +9557,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>27/27 (5d8 + 5)</hp>
+		<hp>27 (5d8 + 5)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9581,10 +9607,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>33/33 (6d8 + 6)</hp>
+		<hp>33 (6d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9631,10 +9657,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>38/38 (7d8 + 7)</hp>
+		<hp>38 (7d8 + 7)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9685,10 +9711,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>44/44 (8d8 + 8)</hp>
+		<hp>44 (8d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -9739,10 +9765,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>49/49 (9d8 + 9)</hp>
+		<hp>49 (9d8 + 9)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9793,10 +9819,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>55/55 (10d8 + 10)</hp>
+		<hp>55 (10d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -9847,10 +9873,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>60/60 (11d8 + 11)</hp>
+		<hp>60 (11d8 + 11)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -9901,10 +9927,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>66/66 (12d8 + 12)</hp>
+		<hp>66 (12d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -9959,10 +9985,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>71/71 (13d8 + 13)</hp>
+		<hp>71 (13d8 + 13)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -10017,10 +10043,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
-		<hp>9/9 (2d8)</hp>
+		<hp>9 (2d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10068,10 +10094,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
-		<hp>13/13 (3d8)</hp>
+		<hp>13 (3d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10119,10 +10145,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
-		<hp>18/18 (4d8)</hp>
+		<hp>18 (4d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10170,10 +10196,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
-		<hp>22/22 (5d8)</hp>
+		<hp>22 (5d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10221,10 +10247,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
-		<hp>27/27 (6d8)</hp>
+		<hp>27 (6d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10274,10 +10300,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
-		<hp>31/31 (7d8)</hp>
+		<hp>31 (7d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10331,10 +10357,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>36/36 (8d8)</hp>
+		<hp>36 (8d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10392,10 +10418,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>40/40 (9d8)</hp>
+		<hp>40 (9d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10453,10 +10479,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>45/45 (10d8)</hp>
+		<hp>45 (10d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10516,10 +10542,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>49/49 (11d8)</hp>
+		<hp>49 (11d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10583,10 +10609,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>54/54 (12d8)</hp>
+		<hp>54 (12d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10652,10 +10678,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>58/58 (13d8)</hp>
+		<hp>58 (13d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10721,10 +10747,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
-		<hp>9/9 (2d8)</hp>
+		<hp>9 (2d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10772,10 +10798,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
-		<hp>13/13 (3d8)</hp>
+		<hp>13 (3d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10823,10 +10849,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
-		<hp>18/18 (4d8)</hp>
+		<hp>18 (4d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10874,10 +10900,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
-		<hp>22/22 (5d8)</hp>
+		<hp>22 (5d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10925,10 +10951,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
-		<hp>27/27 (6d8)</hp>
+		<hp>27 (6d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -10978,10 +11004,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
-		<hp>31/31 (7d8)</hp>
+		<hp>31 (7d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11035,10 +11061,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>36/36 (8d8)</hp>
+		<hp>36 (8d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11096,10 +11122,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>40/40 (9d8)</hp>
+		<hp>40 (9d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11157,10 +11183,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>45/45 (10d8)</hp>
+		<hp>45 (10d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11220,10 +11246,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>49/49 (11d8)</hp>
+		<hp>49 (11d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11287,10 +11313,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>54/54 (12d8)</hp>
+		<hp>54 (12d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11356,10 +11382,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>58/58 (13d8)</hp>
+		<hp>58 (13d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -11425,10 +11451,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>9/9 (2d8)</hp>
+		<hp>9 (2d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11460,10 +11486,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>13/13 (3d8)</hp>
+		<hp>13 (3d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11495,10 +11521,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>18/18 (4d8)</hp>
+		<hp>18 (4d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11530,10 +11556,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>22/22 (5d8)</hp>
+		<hp>22 (5d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11565,10 +11591,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>27/27 (6d8)</hp>
+		<hp>27 (6d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11602,10 +11628,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>31/31 (7d8)</hp>
+		<hp>31 (7d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11643,10 +11669,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>36/36 (8d8)</hp>
+		<hp>36 (8d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11688,10 +11714,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>40/40 (9d8)</hp>
+		<hp>40 (9d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11733,10 +11759,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>45/45 (10d8)</hp>
+		<hp>45 (10d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11780,10 +11806,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>49/49 (11d8)</hp>
+		<hp>49 (11d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11831,10 +11857,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>54/54 (12d8)</hp>
+		<hp>54 (12d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11884,10 +11910,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>58/58 (13d8)</hp>
+		<hp>58 (13d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11937,10 +11963,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 01</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>9/9 (2d8)</hp>
+		<hp>9 (2d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -11972,10 +11998,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 02</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>13/13 (3d8)</hp>
+		<hp>13 (3d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12007,10 +12033,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 03</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>18/18 (4d8)</hp>
+		<hp>18 (4d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12042,10 +12068,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 04</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>22/22 (5d8)</hp>
+		<hp>22 (5d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12077,10 +12103,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 05</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>27/27 (6d8)</hp>
+		<hp>27 (6d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12114,10 +12140,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 06</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
-		<hp>31/31 (7d8)</hp>
+		<hp>31 (7d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12155,10 +12181,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 07</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>36/36 (8d8)</hp>
+		<hp>36 (8d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12200,10 +12226,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 08</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>40/40 (9d8)</hp>
+		<hp>40 (9d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12245,10 +12271,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 09</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>45/45 (10d8)</hp>
+		<hp>45 (10d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12292,10 +12318,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>49/49 (11d8)</hp>
+		<hp>49 (11d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12343,10 +12369,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>54/54 (12d8)</hp>
+		<hp>54 (12d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -12396,10 +12422,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>58/58 (13d8)</hp>
+		<hp>58 (13d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -12447,7 +12473,9 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</monster>
+	
 	<!--Extrapolated Leveling-->
+	
 	<!--Generic-->
 	<monster>
 		<name>Sidekick: Warrior (Attacker) 13</name>
@@ -13406,7 +13434,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>77/77 (14d8 + 14)</hp>
+		<hp>77 (14d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13463,7 +13491,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>82/82 (15d8 + 15)</hp>
+		<hp>82 (15d8 + 15)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13524,7 +13552,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>88/88 (16d8 + 16)</hp>
+		<hp>88 (16d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13586,7 +13614,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>93/93 (17d8 + 17)</hp>
+		<hp>93 (17d8 + 17)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13648,7 +13676,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>99/99 (18d8 + 18)</hp>
+		<hp>99 (18d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13709,7 +13737,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>104/104 (19d8 + 19)</hp>
+		<hp>104 (19d8 + 19)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13774,7 +13802,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>110/110 (20d8 + 20)</hp>
+		<hp>110 (20d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13839,7 +13867,7 @@
 		<type>humanoid, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>115/115 (21d8 + 21)</hp>
+		<hp>115 (21d8 + 21)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>20</dex>
@@ -13909,7 +13937,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>12</dex>
@@ -13963,7 +13991,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>12</dex>
@@ -14021,7 +14049,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>12</dex>
@@ -14081,7 +14109,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>14</dex>
@@ -14141,7 +14169,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>14</dex>
@@ -14203,7 +14231,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>14</dex>
@@ -14269,7 +14297,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>16</dex>
@@ -14335,7 +14363,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>16</dex>
@@ -14405,7 +14433,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>12</dex>
@@ -14459,7 +14487,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>12</dex>
@@ -14517,7 +14545,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>12</dex>
@@ -14577,7 +14605,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>14</dex>
@@ -14637,7 +14665,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>14</dex>
@@ -14699,7 +14727,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>14</dex>
@@ -14765,7 +14793,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>16</dex>
@@ -14831,7 +14859,7 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<str>10</str>
 		<dex>16</dex>
@@ -14896,13 +14924,14 @@
 			<attack>2 hand|+6|1d8</attack>
 		</action>
 	</monster>
+
 	<!--Specific-->
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>105/105 (14d8 + 42)</hp>
+		<hp>105 (14d8 + 42)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -14913,6 +14942,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -14966,10 +14996,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>105/105 (14d8 + 42)</hp>
+		<hp>105 (14d8 + 42)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -14980,6 +15010,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15033,10 +15064,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>112/112 (15d8 + 45)</hp>
+		<hp>112 (15d8 + 45)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -15047,6 +15078,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15100,10 +15132,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>112/112 (15d8 + 45)</hp>
+		<hp>112 (15d8 + 45)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -15114,6 +15146,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15167,10 +15200,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>120/120 (16d8 + 48)</hp>
+		<hp>120 (16d8 + 48)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -15181,6 +15214,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15234,10 +15268,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>120/120 (16d8 + 48)</hp>
+		<hp>120 (16d8 + 48)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -15248,6 +15282,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15301,10 +15336,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>127/127 (17d8 + 51)</hp>
+		<hp>127 (17d8 + 51)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -15315,6 +15350,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15368,10 +15404,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>127/127 (17d8 + 51)</hp>
+		<hp>127 (17d8 + 51)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -15382,6 +15418,7 @@
 		<cha>10</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +10, Perception +6, Survival +6</skill>
+		<resist>poison</resist>
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15435,10 +15472,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>135/135 (18d8 + 54)</hp>
+		<hp>135 (18d8 + 54)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -15449,6 +15486,7 @@
 		<cha>10</cha>
 		<save>Constitution +9</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15502,10 +15540,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>135/135 (18d8 + 54)</hp>
+		<hp>135 (18d8 + 54)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -15516,6 +15554,7 @@
 		<cha>10</cha>
 		<save>Constitution +9</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15569,10 +15608,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>142/142 (19d8 + 57)</hp>
+		<hp>142 (19d8 + 57)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -15583,6 +15622,7 @@
 		<cha>10</cha>
 		<save>Constitution +9</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15640,10 +15680,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>142/142 (19d8 + 57)</hp>
+		<hp>142 (19d8 + 57)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -15654,6 +15694,7 @@
 		<cha>10</cha>
 		<save>Constitution +9</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15711,10 +15752,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>170/170 (20d8 + 80)</hp>
+		<hp>170 (20d8 + 80)</hp>
 		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -15725,6 +15766,7 @@
 		<cha>10</cha>
 		<save>Constitution +10</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15782,10 +15824,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>170/170 (20d8 + 80)</hp>
+		<hp>170 (20d8 + 80)</hp>
 		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -15796,6 +15838,7 @@
 		<cha>10</cha>
 		<save>Constitution +10</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15853,10 +15896,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Attacker) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>178/178 (21d8 + 84)</hp>
+		<hp>178 (21d8 + 84)</hp>
 		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -15867,6 +15910,7 @@
 		<cha>10</cha>
 		<save>Constitution +10</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15924,10 +15968,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Ruby Hammerwhacker (Defender) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, dwarf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>178/178 (21d8 + 84)</hp>
+		<hp>178 (21d8 + 84)</hp>
 		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -15938,6 +15982,7 @@
 		<cha>10</cha>
 		<save>Constitution +10</save>
 		<skill>Athletics +11, Perception +7, Survival +7</skill>
+		<resist>poison</resist>
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
@@ -15995,10 +16040,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -16050,10 +16095,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -16109,10 +16154,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -16170,10 +16215,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -16231,10 +16276,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -16294,10 +16339,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -16361,10 +16406,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -16428,10 +16473,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella Fiasco (Healer) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -16499,10 +16544,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -16554,10 +16599,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -16613,10 +16658,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -16674,10 +16719,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -16735,10 +16780,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -16798,10 +16843,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -16865,10 +16910,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -16932,10 +16977,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Donnabella (Mage) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -17003,10 +17048,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>91/91 (14d8+28)</hp>
+		<hp>91 (14d8+28)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -17074,10 +17119,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>91/91 (14d8+28)</hp>
+		<hp>91 (14d8+28)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -17145,10 +17190,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (15d8+30)</hp>
+		<hp>97 (15d8+30)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -17216,10 +17261,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (15d8+30)</hp>
+		<hp>97 (15d8+30)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -17287,10 +17332,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>104/104 (16d8+32)</hp>
+		<hp>104 (16d8+32)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -17358,10 +17403,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>104/104 (16d8+32)</hp>
+		<hp>104 (16d8+32)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -17429,10 +17474,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>110/110 (17d8+34)</hp>
+		<hp>110 (17d8+34)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -17500,10 +17545,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>110/110 (17d8+34)</hp>
+		<hp>110 (17d8+34)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -17571,10 +17616,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>117/117 (18d8+36)</hp>
+		<hp>117 (18d8+36)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -17642,10 +17687,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>117/117 (18d8+36)</hp>
+		<hp>117 (18d8+36)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -17713,10 +17758,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>123/123 (19d8+38)</hp>
+		<hp>123 (19d8+38)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -17788,10 +17833,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>123/123 (19d8+38)</hp>
+		<hp>123 (19d8+38)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -17863,10 +17908,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>150/150 (20d8+60)</hp>
+		<hp>150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -17938,10 +17983,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>150/150 (20d8+60)</hp>
+		<hp>150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -18013,10 +18058,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Attacker) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>156/156 (21d8+62)</hp>
+		<hp>156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -18088,10 +18133,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Inverna Nightbreeze (Defender) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, elf, sidekick</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>156/156 (21d8+62)</hp>
+		<hp>156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -18163,10 +18208,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>91/91 (14d8+28)</hp>
+		<hp>91 (14d8+28)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -18238,10 +18283,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>91/91 (14d8+28)</hp>
+		<hp>91 (14d8+28)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
@@ -18313,10 +18358,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (15d8+30)</hp>
+		<hp>97 (15d8+30)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -18388,10 +18433,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (15d8+30)</hp>
+		<hp>97 (15d8+30)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -18463,10 +18508,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>104/104 (16d8+32)</hp>
+		<hp>104 (16d8+32)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -18538,10 +18583,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>104/104 (16d8+32)</hp>
+		<hp>104 (16d8+32)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
@@ -18613,10 +18658,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>110/110 (17d8+34)</hp>
+		<hp>110 (17d8+34)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -18688,10 +18733,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>110/110 (17d8+34)</hp>
+		<hp>110 (17d8+34)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -18763,10 +18808,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>117/117 (18d8+36)</hp>
+		<hp>117 (18d8+36)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -18838,10 +18883,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>117/117 (18d8+36)</hp>
+		<hp>117 (18d8+36)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -18913,10 +18958,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>123/123 (19d8+38)</hp>
+		<hp>123 (19d8+38)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -18992,10 +19037,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>123/123 (19d8+38)</hp>
+		<hp>123 (19d8+38)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
@@ -19071,10 +19116,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>150/150 (20d8+60)</hp>
+		<hp>150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -19150,10 +19195,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>150/150 (20d8+60)</hp>
+		<hp>150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -19229,10 +19274,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Attacker) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>156/156 (21d8+62)</hp>
+		<hp>156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -19308,10 +19353,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Quinn Hightopple (Defender) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>156/156 (21d8+62)</hp>
+		<hp>156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
@@ -19387,10 +19432,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>77/77 (14d8 + 14)</hp>
+		<hp>77 (14d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19445,10 +19490,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>82/82 (15d8 + 15)</hp>
+		<hp>82 (15d8 + 15)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19507,10 +19552,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>88/88 (16d8 + 16)</hp>
+		<hp>88 (16d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19570,10 +19615,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>93/93 (17d8 + 17)</hp>
+		<hp>93 (17d8 + 17)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19633,10 +19678,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>99/99 (18d8 + 18)</hp>
+		<hp>99 (18d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19696,10 +19741,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>104/104 (19d8 + 19)</hp>
+		<hp>104 (19d8 + 19)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19763,10 +19808,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>110/110 (20d8 + 20)</hp>
+		<hp>110 (20d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19830,10 +19875,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Galandro Luna 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>115/115 (21d8 + 21)</hp>
+		<hp>115 (21d8 + 21)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19902,10 +19947,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>77/77 (14d8 + 14)</hp>
+		<hp>77 (14d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -19960,10 +20005,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>82/82 (15d8 + 15)</hp>
+		<hp>82 (15d8 + 15)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20022,10 +20067,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>88/88 (16d8 + 16)</hp>
+		<hp>88 (16d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20085,10 +20130,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>93/93 (17d8 + 17)</hp>
+		<hp>93 (17d8 + 17)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20148,10 +20193,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>99/99 (18d8 + 18)</hp>
+		<hp>99 (18d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20211,10 +20256,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>104/104 (19d8 + 19)</hp>
+		<hp>104 (19d8 + 19)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20278,10 +20323,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>110/110 (20d8 + 20)</hp>
+		<hp>110 (20d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20345,10 +20390,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Pickled Pete 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>115/115 (21d8 + 21)</hp>
+		<hp>115 (21d8 + 21)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20417,10 +20462,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>77/77 (14d8 + 14)</hp>
+		<hp>77 (14d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20475,10 +20520,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>82/82 (15d8 + 15)</hp>
+		<hp>82 (15d8 + 15)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20537,10 +20582,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>88/88 (16d8 + 16)</hp>
+		<hp>88 (16d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20600,10 +20645,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>93/93 (17d8 + 17)</hp>
+		<hp>93 (17d8 + 17)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20663,10 +20708,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>99/99 (18d8 + 18)</hp>
+		<hp>99 (18d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20726,10 +20771,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>104/104 (19d8 + 19)</hp>
+		<hp>104 (19d8 + 19)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20793,10 +20838,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>110/110 (20d8 + 20)</hp>
+		<hp>110 (20d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20860,10 +20905,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Talon Thornwild 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>17 (studded leather)</ac>
-		<hp>115/115 (21d8 + 21)</hp>
+		<hp>115 (21d8 + 21)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>11</str>
@@ -20932,10 +20977,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -21003,10 +21048,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -21078,10 +21123,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -21155,10 +21200,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>15 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>10</str>
@@ -21232,10 +21277,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>15 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>10</str>
@@ -21311,10 +21356,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>15 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>10</str>
@@ -21394,10 +21439,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>10</str>
@@ -21477,10 +21522,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Mage) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>S</size>
 		<ac>16 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>10</str>
@@ -21564,10 +21609,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -21635,10 +21680,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -21710,10 +21755,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>10</str>
@@ -21787,10 +21832,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>10</str>
@@ -21864,10 +21909,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>10</str>
@@ -21943,10 +21988,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>25 ft.</speed>
 		<init>3</init>
 		<str>10</str>
@@ -22026,10 +22071,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>10</str>
@@ -22109,10 +22154,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Nib Addlespur (Healer) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, halfling, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>10</str>
@@ -22196,10 +22241,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -22251,10 +22296,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -22310,10 +22355,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>11</str>
@@ -22371,10 +22416,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -22432,10 +22477,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -22495,10 +22540,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -22562,10 +22607,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -22629,10 +22674,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Mage) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -22700,10 +22745,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>63/63 (14d8)</hp>
+		<hp>63 (14d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -22755,10 +22800,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>67/67 (15d8)</hp>
+		<hp>67 (15d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -22814,10 +22859,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
-		<hp>72/72 (16d8)</hp>
+		<hp>72 (16d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>11</str>
@@ -22875,10 +22920,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>76/76 (17d8)</hp>
+		<hp>76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -22936,10 +22981,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>81/81 (18d8)</hp>
+		<hp>81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -22999,10 +23044,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
-		<hp>85/85 (19d8)</hp>
+		<hp>85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>11</str>
@@ -23066,10 +23111,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>90/90 (20d8)</hp>
+		<hp>90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>
@@ -23133,10 +23178,10 @@
 	</monster>
 	<monster>
 		<name>Sidekick: Shajan Kwan (Healer) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>humanoid, human, sidekick</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
-		<hp>94/94 (21d8)</hp>
+		<hp>94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>11</str>

--- a/Bestiary/Storm King's Thunder.xml
+++ b/Bestiary/Storm King's Thunder.xml
@@ -1070,4 +1070,93 @@
 			<text>Flaw: "I'll risk life and limb to become a legend.-"</text>
 		</trait>
 	</monster>
+	<monster>
+		<name>Claugiyliamatar</name>
+		<size>G</size>
+		<type>dragon</type>
+		<description>Source: Monster Manual</description>
+		<alignment>lawful evil</alignment>
+		<ac>21 (natural armor)</ac>
+		<hp>385 (22d20+154)</hp>
+		<speed>40 ft., fly 80 ft., swim 40 ft.</speed>
+		<str>27</str>
+		<dex>12</dex>
+		<con>25</con>
+		<int>20</int>
+		<wis>17</wis>
+		<cha>19</cha>
+		<save>Dex +8, Con +14, Wis +10, Cha +11</save>
+		<skill>Deception +11, Insight +10, Perception +17, Persuasion +11, Stealth +8</skill>
+		<immune>poison</immune>
+		<conditionImmune>poisoned</conditionImmune>
+		<senses>blindsight 60 ft., darkvision 120 ft.</senses>
+		<passive>27</passive>
+		<languages>Common, Draconic</languages>
+		<cr>23</cr>
+		<trait>
+			<name>Amphibious</name>
+			<text>The dragon can breathe air and water.</text>
+		</trait>
+		<trait>
+			<name>Legendary Resistance (3/Day)</name>
+			<text>If the dragon fails a saving throw, it can choose to succeed instead.</text>
+		</trait>
+		<trait>
+			<name>Innate Spellcasting</name>
+			<text>Claugiyliamatar’s spellcasting ability is Charisma (spell save DC 19). She can innately cast the following spells, requiring no material components:</text>
+			<text>1/day each: invisibility, legend lore, protection from energy, true seeing</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Claugiyliamatar is an 8th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 18; +10 to hit with spell attacks). She has the following druid spells prepared:</text>
+			<text>Cantrips (at will): druidcraft, mending, produce flame</text>
+			<text>1st level (4 slots): cure wounds, detect magic, entangle, speak with animals</text>
+			<text>2nd level (3 slots): animal messenger, pass without trace</text>
+			<text>3rd level (3 slots): dispel magic, plant growth</text>
+			<text>4th level (2 slots): blight, locate creature, stoneskin</text>
+		</trait>
+		<spellAbility>Wisdom</spellAbility>
+		<slots>4,3,3,2,0,0,0,0,0</slots>
+		<spells>Druidcraft, Mending, Produce Flame, Cure Wounds, Detect Magic, Entangle, Speak with Animals, Animal Messenger, Pass without Trace, Dispel Magic, Plant Growth, Blight, Locate Creature, Stoneskin</spells>
+		<action>
+			<name>Multiattack</name>
+			<text>The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.</text>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 10 (3d6) poison damage.</text>
+			<attack>Bite|15|2d10+8+3d6</attack>
+		</action>
+		<action>
+			<name>Claw</name>
+			<text>Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 22 (4d6 + 8) slashing damage.</text>
+			<attack>Claw|15|4d6+8</attack>
+		</action>
+		<action>
+			<name>Tail</name>
+			<text>Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.</text>
+			<attack>Tail|15|2d8+8</attack>
+		</action>
+		<action>
+			<name>Frightful Presence</name>
+			<text>Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.</text>
+		</action>
+		<action>
+			<name>Poison Breath (Recharge 5-6)</name>
+			<text>The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one.</text>
+			<attack>Poison Breath||22d6</attack>
+		</action>
+		<legendary>
+			<name>Detect</name>
+			<text>The dragon makes a Wisdom (Perception) check.</text>
+		</legendary>
+		<legendary>
+			<name>Tail Attack</name>
+			<text>The dragon makes a tail attack.</text>
+		</legendary>
+		<legendary>
+			<name>Wing Attack (Costs 2 Actions)</name>
+			<text>The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.</text>
+		</legendary>
+	</monster>
 </compendium>

--- a/Bestiary/Tales From the Yawining Portal.xml
+++ b/Bestiary/Tales From the Yawining Portal.xml
@@ -466,8 +466,7 @@
 		<immune>poison</immune>
 		<conditionImmune>charmed, exhaustion, frightened, paralyzed, poisoned</conditionImmune>
 		<senses>darkvision 60 ft.</senses>
-		<passive>8
-</passive>
+		<passive>8</passive>
 		<languages>understands the languages it knew in life but can't speak</languages>
 		<cr>5</cr>
 		<trait>

--- a/GM5/Sidekicks/Generic/Expert.xml
+++ b/GM5/Sidekicks/Generic/Expert.xml
@@ -1,0 +1,711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Expert</label>
+		<name>Expert 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>15</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +4</save>
+		<skill>Acrobatics +4</text>
+		<skill>Performance +4</text>
+		<skill>Persuasion +4</text>
+		<skill>Sleight of Hand +4</text>
+		<skill>Stealth +4</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>|+4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>15</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +4</save>
+		<skill>Acrobatics +4</text>
+		<skill>Performance +4</text>
+		<skill>Persuasion +4</text>
+		<skill>Sleight of Hand +4</text>
+		<skill>Stealth +4</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>|+4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>15</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +4</save>
+		<skill>Acrobatics +4</text>
+		<skill>Performance +4</text>
+		<skill>Persuasion +4</text>
+		<skill>Sleight of Hand +4</text>
+		<skill>Stealth +4</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.</text>
+			<attack>|+4|1d4+2</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>17</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</text>
+		<skill>Performance +4</text>
+		<skill>Persuasion +4</text>
+		<skill>Sleight of Hand +5</text>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>17</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6</text>
+		<skill>Performance +5</text>
+		<skill>Persuasion +5</text>
+		<skill>Sleight of Hand +6</text>
+		<skill>Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>17</dex>
+		<con>12</con>
+		<int>13</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6</text>
+		<skill>Performance +5</text>
+		<skill>Persuasion +5</text>
+		<skill>Sleight of Hand +6</text>
+		<skill>Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9</text>
+		<skill>Performance +5</text>
+		<skill>Persuasion +5</text>
+		<skill>Sleight of Hand +6</text>
+		<skill>Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10</text>
+		<skill>Performance +5</text>
+		<skill>Persuasion +5</text>
+		<skill>Sleight of Hand +7</text>
+		<skill>Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12</text>
+		<skill>Performance +6</text>
+		<skill>Persuasion +6</text>
+		<skill>Sleight of Hand +8</text>
+		<skill>Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +8 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</text>
+		<skill>Performance +6</text>
+		<skill>Persuasion +6</text>
+		<skill>Sleight of Hand +9</text>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>14</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</text>
+		<skill>Performance +6</text>
+		<skill>Persuasion +6</text>
+		<skill>Sleight of Hand +9</text>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</text>
+		<skill>Performance +7</text>
+		<skill>Persuasion +7</text>
+		<skill>Sleight of Hand +9</text>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Generic/Expert.xml
+++ b/GM5/Sidekicks/Generic/Expert.xml
@@ -354,10 +354,6 @@
 			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
 		</trait>
 		<trait>
-			<name>Expertise</name>
-			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
-		</trait>
-		<trait>
 			<name>Helpful</name>
 			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
 		</trait>
@@ -415,10 +411,6 @@
 		<trait>
 			<name>Extra Attack</name>
 			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
-		</trait>
-		<trait>
-			<name>Expertise</name>
-			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
 		</trait>
 		<trait>
 			<name>Helpful</name>
@@ -480,10 +472,6 @@
 			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
 		</trait>
 		<trait>
-			<name>Expertise</name>
-			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
-		</trait>
-		<trait>
 			<name>Helpful</name>
 			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
 		</trait>
@@ -541,10 +529,6 @@
 		<trait>
 			<name>Extra Attack</name>
 			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
-		</trait>
-		<trait>
-			<name>Expertise</name>
-			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
 		</trait>
 		<trait>
 			<name>Helpful</name>
@@ -610,10 +594,6 @@
 			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
 		</trait>
 		<trait>
-			<name>Expertise</name>
-			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
-		</trait>
-		<trait>
 			<name>Helpful</name>
 			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
 		</trait>
@@ -675,10 +655,6 @@
 		<trait>
 			<name>Extra Attack</name>
 			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
-		</trait>
-		<trait>
-			<name>Expertise</name>
-			<text>Choose two of the expert’s skill proficiencies. The proficiency bonus is doubled for any ability check the expert makes that uses either of the chosen proficiencies.</text>
 		</trait>
 		<trait>
 			<name>Helpful</name>

--- a/GM5/Sidekicks/Generic/Expert.xml
+++ b/GM5/Sidekicks/Generic/Expert.xml
@@ -16,10 +16,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +4</save>
-		<skill>Acrobatics +4</text>
-		<skill>Performance +4</text>
-		<skill>Persuasion +4</text>
-		<skill>Sleight of Hand +4</text>
+		<skill>Acrobatics +4</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +4</skill>
 		<skill>Stealth +4</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -63,10 +63,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +4</save>
-		<skill>Acrobatics +4</text>
-		<skill>Performance +4</text>
-		<skill>Persuasion +4</text>
-		<skill>Sleight of Hand +4</text>
+		<skill>Acrobatics +4</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +4</skill>
 		<skill>Stealth +4</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -114,10 +114,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +4</save>
-		<skill>Acrobatics +4</text>
-		<skill>Performance +4</text>
-		<skill>Persuasion +4</text>
-		<skill>Sleight of Hand +4</text>
+		<skill>Acrobatics +4</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +4</skill>
 		<skill>Stealth +4</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -169,10 +169,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +5</save>
-		<skill>Acrobatics +5</text>
-		<skill>Performance +4</text>
-		<skill>Persuasion +4</text>
-		<skill>Sleight of Hand +5</text>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
 		<skill>Stealth +5</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -224,10 +224,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +6</save>
-		<skill>Acrobatics +6</text>
-		<skill>Performance +5</text>
-		<skill>Persuasion +5</text>
-		<skill>Sleight of Hand +6</text>
+		<skill>Acrobatics +6</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +6</skill>
 		<skill>Stealth +6</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -279,10 +279,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +6</save>
-		<skill>Acrobatics +6</text>
-		<skill>Performance +5</text>
-		<skill>Persuasion +5</text>
-		<skill>Sleight of Hand +6</text>
+		<skill>Acrobatics +6</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +6</skill>
 		<skill>Stealth +6</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -338,10 +338,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +6</save>
-		<skill>Acrobatics +9</text>
-		<skill>Performance +5</text>
-		<skill>Persuasion +5</text>
-		<skill>Sleight of Hand +6</text>
+		<skill>Acrobatics +9</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +6</skill>
 		<skill>Stealth +9</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -397,10 +397,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +7</save>
-		<skill>Acrobatics +10</text>
-		<skill>Performance +5</text>
-		<skill>Persuasion +5</text>
-		<skill>Sleight of Hand +7</text>
+		<skill>Acrobatics +10</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
 		<skill>Stealth +10</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -456,10 +456,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +8</save>
-		<skill>Acrobatics +12</text>
-		<skill>Performance +6</text>
-		<skill>Persuasion +6</text>
-		<skill>Sleight of Hand +8</text>
+		<skill>Acrobatics +12</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +8</skill>
 		<skill>Stealth +12</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -515,10 +515,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +9</save>
-		<skill>Acrobatics +13</text>
-		<skill>Performance +6</text>
-		<skill>Persuasion +6</text>
-		<skill>Sleight of Hand +9</text>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
 		<skill>Stealth +13</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -574,10 +574,10 @@
 		<wis>10</wis>
 		<cha>14</cha>
 		<save>Dexterity +9</save>
-		<skill>Acrobatics +13</text>
-		<skill>Performance +6</text>
-		<skill>Persuasion +6</text>
-		<skill>Sleight of Hand +9</text>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
 		<skill>Stealth +13</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -637,10 +637,10 @@
 		<wis>10</wis>
 		<cha>16</cha>
 		<save>Dexterity +9</save>
-		<skill>Acrobatics +13</text>
-		<skill>Performance +7</text>
-		<skill>Persuasion +7</text>
-		<skill>Sleight of Hand +9</text>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +7</skill>
+		<skill>Persuasion +7</skill>
+		<skill>Sleight of Hand +9</skill>
 		<skill>Stealth +13</skill>
 		<passive>10</passive>
 		<languages>Common, plus one of your choice</languages>
@@ -682,6 +682,563 @@
 			<name>Shortbow</name>
 			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
 			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Expert</label>
+		<name>Expert 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +8</skill>
+		<skill>Persuasion +8</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +8</skill>
+		<skill>Persuasion +8</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>16</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +8</skill>
+		<skill>Persuasion +8</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>18</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +10</skill>
+		<skill>Persuasion +10</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>18</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +10</skill>
+		<skill>Persuasion +10</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Expert</label>
+		<name>Expert 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>20</dex>
+		<con>12</con>
+		<int>14</int>
+		<wis>10</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>The expert has an uncanny knack for succeeding when they need to. If their attack misses a target within range, they can turn the miss into a hit. Alternatively, if they fail an ability check, they can treat the d20 roll as a 20.</text>
+			<text>The expert can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>The expert is so evasive that attackers rarely gain the upper hand against them. No attack roll has advantage against them while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If the expert is able to hear, the expert is aware of the location of any hidden or invisible creature within 10 feet of them.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever the expert makes an ability check that includes its whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When the expert is not incapacitated and subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The expert can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>The expert can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>The expert has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On the expert’s turn in combat, it can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
 		</action>
 	</npc>
 </characters>

--- a/GM5/Sidekicks/Generic/Spellcaster (Healer).xml
+++ b/GM5/Sidekicks/Generic/Spellcaster (Healer).xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <characters version="5">
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 1</name>
 		<type>Humanoid</type>
@@ -38,7 +38,7 @@
 			<attack>2 hand|+2|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 2</name>
 		<type>Humanoid</type>
@@ -76,7 +76,7 @@
 			<attack>2 hand|+2|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 3</name>
 		<type>Humanoid</type>
@@ -114,7 +114,7 @@
 			<attack>2 hand|+2|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 4</name>
 		<type>Humanoid</type>
@@ -152,7 +152,7 @@
 			<attack>2 hand|+2|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 5</name>
 		<type>Humanoid</type>
@@ -192,7 +192,7 @@
 			<attack>2 hand|+3|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 6</name>
 		<type>Humanoid</type>
@@ -236,7 +236,7 @@
 			<attack>2 hand|+3|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 7</name>
 		<type>Humanoid</type>
@@ -284,7 +284,7 @@
 			<attack>2 hand|+3|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 8</name>
 		<type>Humanoid</type>
@@ -332,7 +332,7 @@
 			<attack>2 hand|+3|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 9</name>
 		<type>Humanoid</type>
@@ -382,7 +382,7 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 10</name>
 		<type>Humanoid</type>
@@ -436,7 +436,7 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 11</name>
 		<type>Humanoid</type>
@@ -492,7 +492,7 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</npc>
-<npc>
+	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 12</name>
 		<type>Humanoid</type>
@@ -546,6 +546,536 @@
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
 			<attack>|+4|1d6</attack>
 			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>The spellcaster can choose one 3rd level spell. The spellcaster can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
 		</action>
 	</npc>
 </characters>

--- a/GM5/Sidekicks/Generic/Spellcaster (Healer).xml
+++ b/GM5/Sidekicks/Generic/Spellcaster (Healer).xml
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>13</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>13</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>13</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The spellcaster has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Generic/Spellcaster (Healer).xml
+++ b/GM5/Sidekicks/Generic/Spellcaster (Healer).xml
@@ -739,7 +739,7 @@
 		<name>Spellcaster (Healer) 16</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
@@ -803,7 +803,7 @@
 		<name>Spellcaster (Healer) 17</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
@@ -869,7 +869,7 @@
 		<name>Spellcaster (Healer) 18</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
@@ -939,7 +939,7 @@
 		<name>Spellcaster (Healer) 19</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
@@ -1009,7 +1009,7 @@
 		<name>Spellcaster (Healer) 20</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>

--- a/GM5/Sidekicks/Generic/Spellcaster (Mage).xml
+++ b/GM5/Sidekicks/Generic/Spellcaster (Mage).xml
@@ -548,4 +548,534 @@
 			<attack>2 hand|+4|1d8</attack>
 		</action>
 	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12</skill>
+		<skill>Investigation +12</skill>
+		<skill>Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12</skill>
+		<skill>Investigation +12</skill>
+		<skill>Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>The spellcaster can choose one 3rd level spell. The spellcaster can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>The spellcaster has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are the spellcaster knows. The spellcaster can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>The spellcaster can increase the power of their simpler spells. When the spellcaster casts a spell of 5th level or lower that deals damage or heals, the spellcaster can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
 </characters>

--- a/GM5/Sidekicks/Generic/Spellcaster (Mage).xml
+++ b/GM5/Sidekicks/Generic/Spellcaster (Mage).xml
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>13</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>16</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Mage)</label>
+		<name>Spellcaster (Mage) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>10</str>
+		<dex>12</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>The spellcaster can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>The spellcaster’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The spellcaster has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Generic/Spellcaster (Mage).xml
+++ b/GM5/Sidekicks/Generic/Spellcaster (Mage).xml
@@ -739,7 +739,7 @@
 		<name>Spellcaster (Mage) 16</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
@@ -803,7 +803,7 @@
 		<name>Spellcaster (Mage) 17</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
@@ -869,7 +869,7 @@
 		<name>Spellcaster (Mage) 18</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>14 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
@@ -939,7 +939,7 @@
 		<name>Spellcaster (Mage) 19</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
@@ -1009,7 +1009,7 @@
 		<name>Spellcaster (Mage) 20</name>
 		<type>Humanoid</type>
 		<size>M</size>
-		<ac>13 (studded leather)</ac>
+		<ac>15 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>

--- a/GM5/Sidekicks/Generic/Warrior.xml
+++ b/GM5/Sidekicks/Generic/Warrior.xml
@@ -1,0 +1,2259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack twice, instead of once, whenever it takes the Attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+9|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. If it does so, it can’t use this feature again until it finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack three times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Warrior (Attacker)</label>
+		<name>Warrior (Attacker) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack four times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>The warrior gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Warrior (Defender)</label>
+		<name>Warrior (Defender) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If the warrior's total for a strength check is less than the warrior's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>The warrior’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>The warrior can reroll a saving throw that it fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>The warrior has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>The warrior can attack four times, instead of once, whenever it takes the attack action on its turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>The warrior’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>The warrior can use a bonus action on its turn to regain hit points equal to 1d10 + its level. It can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>The warrior imposes disadvantage on the attack roll of a creature within 5 feet of it whose target isn’t the warrior. The warrior must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Donnabella Fiasco (Healer).xml
+++ b/GM5/Sidekicks/Specific/Donnabella Fiasco (Healer).xml
@@ -1,0 +1,1081 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. Donnabella can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. Donnabella can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella Fiasco (Healer)</label>
+		<name>Donnabella Fiasco (Healer) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Donnabella can choose one 3rd level spell. Donnabella can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. Donnabella can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Donnabella casts a spell of that school by expending a spell slot, she can add her spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). She has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Donnabella Fiasco (Mage).xml
+++ b/GM5/Sidekicks/Specific/Donnabella Fiasco (Mage).xml
@@ -1,0 +1,1081 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>17</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. She can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. She can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Donnabella (Mage)</label>
+		<name>Donnabella (Mage) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Donnabella can choose one 3rd level spell. She can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Donnabella has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are she knows. She can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Donnabella can increase the power of their simpler spells. When she casts a spell of 5th level or lower that deals damage or heals, she can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever the spellcaster casts a spell of that school by expending a spell slot, the spellcaster can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Donnabella can add her spellcasting ability modifier to the damage she deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Donnabella’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). She has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Galandro Luna.xml
+++ b/GM5/Sidekicks/Specific/Galandro Luna.xml
@@ -1,0 +1,1244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Galandro’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +6</skill>
+		<skill>Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Galandro’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Galandro’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Galandro’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +6</skill>
+		<skill>Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +8</skill>
+		<skill>Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</npc>
+		<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +8</skill>
+		<skill>Persuasion +8</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15</skill>
+		<skill>Performance +10</skill>
+		<skill>Persuasion +10</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Galandro is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Galandro is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Galandro Luna</label>
+		<name>Galandro Luna 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>Galandro has an uncanny knack for succeeding when they need to. If his attack misses a target within range, he can turn the miss into a hit. Alternatively, if he fail an ability check, he can treat the d20 roll as a 20.</text>
+			<text>Galandro can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>Galandro is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Galandro is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Galandro makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Galandro is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Galandro can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Galandro can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Galandro has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Galandro’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Inverna Nightbreeze.xml
+++ b/GM5/Sidekicks/Specific/Inverna Nightbreeze.xml
@@ -1,0 +1,2259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+9|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Attacker)</label>
+		<name>Warrior (Attacker) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Inverna Nightbreeze (Defender)</label>
+		<name>Warrior (Defender) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Inverna’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Inverna has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Inverna can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Inverna’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Inverna Nightbreeze.xml
+++ b/GM5/Sidekicks/Specific/Inverna Nightbreeze.xml
@@ -10,20 +10,33 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -33,8 +46,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
 		</action>
 	</npc>
 	<npc>
@@ -47,17 +60,30 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -66,8 +92,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -84,17 +110,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Second Wind</name>
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
@@ -104,6 +131,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -112,8 +151,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
 		</action>
 	</npc>
 	<npc>
@@ -126,21 +165,34 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Second Wind</name>
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -150,8 +202,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -168,17 +220,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -192,6 +245,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -200,8 +265,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
 		</action>
 	</npc>
 	<npc>
@@ -214,17 +279,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -234,6 +300,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+3</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -242,8 +320,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -260,17 +338,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +5</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -284,6 +363,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -292,8 +383,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
 		</action>
 	</npc>
 	<npc>
@@ -306,17 +397,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +4</save>
+		<skill>Acrobatics +4</skill>
 		<skill>Athletics +5</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -326,6 +418,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+4</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -334,8 +438,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+3|1d8+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -352,17 +456,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +5</skill>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -376,6 +481,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -384,8 +501,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+6|1d8+1</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
 		</action>
 	</npc>
 	<npc>
@@ -398,17 +515,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +5</skill>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Inverna’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -418,6 +536,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+5</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -426,8 +556,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+4|1d8+1</attack>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+4|1d8+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -444,17 +574,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +5</skill>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Extra Attack</name>
 			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
@@ -472,6 +603,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -480,8 +623,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+6|1d8+1</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
 		</action>
 	</npc>
 	<npc>
@@ -494,17 +637,18 @@
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +5</skill>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Extra Attack</name>
 			<text>Inverna can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
@@ -518,6 +662,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+6</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -526,8 +682,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+4|1d8+1</attack>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+4|1d8+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -544,17 +700,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +6</skill>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Inverna has advantage on initiative rolls.</text>
@@ -576,6 +733,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -584,8 +753,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -598,17 +767,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +6</skill>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Inverna has advantage on initiative rolls.</text>
@@ -626,6 +796,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+7</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -634,8 +816,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+5|1d8+2</attack>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+5|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -652,17 +834,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +6</skill>
 		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Inverna has advantage on initiative rolls.</text>
@@ -684,6 +867,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -692,8 +887,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -706,17 +901,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
+		<skill>Acrobatics +6</skill>
 		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Inverna has advantage on initiative rolls.</text>
@@ -734,6 +930,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+8</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -742,8 +950,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+5|1d8+2</attack>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+5|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -760,17 +968,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
@@ -796,6 +1005,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -804,8 +1025,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -818,17 +1039,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Inverna can reroll a saving throw that she fails but must use the new result.</text>
@@ -850,6 +1072,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+9</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -858,8 +1092,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -876,17 +1110,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -916,6 +1151,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -924,8 +1171,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -938,17 +1185,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -974,6 +1222,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+10</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -982,8 +1242,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1000,17 +1260,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1040,6 +1301,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -1048,8 +1321,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1062,17 +1335,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1098,6 +1372,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+11</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -1106,8 +1392,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1124,17 +1410,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1164,6 +1451,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1172,8 +1471,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1186,17 +1485,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
+		<skill>Acrobatics +7</skill>
 		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1222,6 +1522,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+12</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1230,15 +1542,14 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+6|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
 			<text>Inverna imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Inverna. Inverna must be able to see the attacker.</text>
 		</reaction>
 	</npc>
-
 	<!--Extrapolated Leveling-->
 	<npc>
 		<label>Inverna Nightbreeze (Attacker)</label>
@@ -1250,17 +1561,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +8</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1290,6 +1602,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1298,8 +1622,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+9|1d8+2</attack>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+9|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1312,17 +1636,18 @@
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +8</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1348,6 +1673,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+13</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1356,8 +1693,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1374,17 +1711,18 @@
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +9</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1414,6 +1752,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1422,8 +1772,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+10|1d8+3</attack>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1436,17 +1786,18 @@
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +9</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1472,6 +1823,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+14</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1480,8 +1843,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+8|1d8+3</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+8|1d8+4</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1498,17 +1861,18 @@
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +9</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1538,6 +1902,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1546,8 +1922,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+10|1d8+3</attack>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1560,17 +1936,18 @@
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +9</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1596,6 +1973,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+15</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1604,8 +1993,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+8|1d8+3</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+8|1d8+4</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1622,17 +2011,18 @@
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +10</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1662,6 +2052,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1670,8 +2072,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+11|1d8+4</attack>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1684,17 +2086,18 @@
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +7</save>
+		<skill>Acrobatics +10</skill>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1720,6 +2123,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+16</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1728,8 +2143,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+9|1d8+4</attack>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+9|1d8+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1746,17 +2161,18 @@
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1786,6 +2202,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1794,8 +2222,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+12|1d8+4</attack>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+12|1d8+5</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1808,17 +2236,18 @@
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Inverna’s AC increases by 1.</text>
@@ -1844,6 +2273,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+17</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1852,8 +2293,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+10|1d8+4</attack>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+10|1d8+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1870,17 +2311,18 @@
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
@@ -1914,6 +2356,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1922,8 +2376,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+12|1d8+4</attack>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+12|1d8+5</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1936,17 +2390,18 @@
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
-		<int>10</int>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
@@ -1976,6 +2431,18 @@
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+18</roll>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1984,8 +2451,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+10|1d8+4</attack>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+10|1d8+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1998,21 +2465,22 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>130/130 (20d8+40)</hp>
+		<hp>150/150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
-		<int>10</int>
+		<con>16</con>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
@@ -2045,6 +2513,18 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2064,21 +2544,22 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>130/130 (20d8+40)</hp>
+		<hp>150/150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
-		<int>10</int>
+		<con>16</con>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
@@ -2107,6 +2588,18 @@
 			<name>Second Wind (2 uses)</name>
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2130,21 +2623,22 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>136/136 (21d8+42)</hp>
+		<hp>156/156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
-		<int>10</int>
+		<con>16</con>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
@@ -2178,6 +2672,18 @@
 			<name>Martial Role: Attacker</name>
 			<text>Inverna gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -2196,21 +2702,22 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>136/136 (21d8+42)</hp>
+		<hp>156/156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
-		<int>10</int>
+		<con>16</con>
+		<int>11</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +8</save>
+		<skill>Acrobatics +11</skill>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Elvish, plus one of your choice</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Inverna's total for a strength check is less than Inverna's strength score, the score can be used in place of the total.</text>
@@ -2239,6 +2746,18 @@
 			<name>Second Wind (2 uses)</name>
 			<text>Inverna can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to twilit forests and the night sky, Inverna have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Fey Ancestry</name>
+			<text>Inverna has advantage on saving throws against being charmed, and magic can't put her to sleep</text>
+		</trait>
+		<trait>
+			<name>Trance</name>
+			<text>Elves don't need to sleep. Instead,they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is "trance.") While meditating, Inverna can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, she gains the same benefit that a human does from 8 hours of sleep.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>

--- a/GM5/Sidekicks/Specific/Nib Addlespur (Healer).xml
+++ b/GM5/Sidekicks/Specific/Nib Addlespur (Healer).xml
@@ -3,7 +3,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 1</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
 		<hp>9/9 (2d8)</hp>
@@ -57,7 +57,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 2</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
 		<hp>13/13 (3d8)</hp>
@@ -111,7 +111,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 3</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
 		<hp>18/18 (4d8)</hp>
@@ -165,7 +165,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 4</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
 		<hp>22/22 (5d8)</hp>
@@ -219,7 +219,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 5</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
 		<hp>27/27 (6d8)</hp>
@@ -275,7 +275,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 6</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (leather)</ac>
 		<hp>31/31 (7d8)</hp>
@@ -335,7 +335,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 7</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>36/36 (8d8)</hp>
@@ -399,7 +399,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 8</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>40/40 (9d8)</hp>
@@ -463,7 +463,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 9</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>45/45 (10d8)</hp>
@@ -529,7 +529,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>49/49 (11d8)</hp>
@@ -599,7 +599,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>54/54 (12d8)</hp>
@@ -671,7 +671,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>58/58 (13d8)</hp>
@@ -745,7 +745,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>63/63 (14d8)</hp>
@@ -819,7 +819,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>67/67 (15d8)</hp>
@@ -897,7 +897,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>72/72 (16d8)</hp>
@@ -977,7 +977,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
@@ -1057,7 +1057,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
@@ -1139,7 +1139,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
@@ -1225,7 +1225,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
@@ -1311,7 +1311,7 @@
 	<npc>
 		<label>Nib Addlespur (Healer)</label>
 		<name>Nib Addlespur (Healer) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>

--- a/GM5/Sidekicks/Specific/Nib Addlespur (Healer).xml
+++ b/GM5/Sidekicks/Specific/Nib Addlespur (Healer).xml
@@ -1,0 +1,1401 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 1</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 2</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 3</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 4</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 5</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 6</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 7</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>16</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 8</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 9</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>18</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Healer)</label>
+		<name>Nib Addlespur (Healer) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Nib can choose one 3rd level spell. Nib can cast thers spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Nib has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Nib Addlespur (Mage).xml
+++ b/GM5/Sidekicks/Specific/Nib Addlespur (Mage).xml
@@ -3,7 +3,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 1</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
 		<hp>9/9 (2d8)</hp>
@@ -57,7 +57,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 2</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
 		<hp>13/13 (3d8)</hp>
@@ -111,7 +111,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 3</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
 		<hp>18/18 (4d8)</hp>
@@ -165,7 +165,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 4</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
 		<hp>22/22 (5d8)</hp>
@@ -219,7 +219,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 5</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
 		<hp>27/27 (6d8)</hp>
@@ -275,7 +275,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 6</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>13 (leather)</ac>
 		<hp>31/31 (7d8)</hp>
@@ -335,7 +335,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 7</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>36/36 (8d8)</hp>
@@ -399,7 +399,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 8</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>40/40 (9d8)</hp>
@@ -463,7 +463,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 9</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>45/45 (10d8)</hp>
@@ -529,7 +529,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>49/49 (11d8)</hp>
@@ -599,7 +599,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>54/54 (12d8)</hp>
@@ -671,7 +671,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>58/58 (13d8)</hp>
@@ -745,7 +745,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>63/63 (14d8)</hp>
@@ -819,7 +819,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>67/67 (15d8)</hp>
@@ -897,7 +897,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>14 (studded leather)</ac>
 		<hp>72/72 (16d8)</hp>
@@ -977,7 +977,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>15 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
@@ -1057,7 +1057,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>15 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
@@ -1139,7 +1139,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>15 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
@@ -1225,7 +1225,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>16 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
@@ -1311,7 +1311,7 @@
 	<npc>
 		<label>Nib Addlespur (Mage)</label>
 		<name>Nib Addlespur (Mage) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>S</size>
 		<ac>16 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>

--- a/GM5/Sidekicks/Specific/Nib Addlespur (Mage).xml
+++ b/GM5/Sidekicks/Specific/Nib Addlespur (Mage).xml
@@ -1,0 +1,1401 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 1</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 2</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 3</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>15</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 4</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 5</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 6</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>13 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>17</int>
+		<wis>14</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 7</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>16</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 8</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 9</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>18</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>10</str>
+		<dex>14</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>10</str>
+		<dex>16</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12</skill>
+		<skill>Investigation +12</skill>
+		<skill>Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Nib Addlespur (Mage)</label>
+		<name>Nib Addlespur (Mage) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>S</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>10</str>
+		<dex>18</dex>
+		<con>10</con>
+		<int>20</int>
+		<wis>14</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +12</skill>
+		<skill>Investigation +12</skill>
+		<skill>Religion +12</skill>
+		<passive>12</passive>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Nib rolls a 1 on an attack roll, ability check, or saving throw, she can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Nib have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Nib can move through the space of any creature that is of a size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Nib can attempt to hide even when she is obscured only by a creature that is at least one size larger than her.</text>
+		</trait>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Nib can choose one 3rd level spell. Nib can cast thers spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Nib has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Nib knows. Nib can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Nib can increase the power of their simpler spells. When Nib casts a spell of 5th level or lower that deals damage or heals, Nib can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Nib casts a spell of that school by expending a spell slot, Nib can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Nib can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Nib’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Nib has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Pickled Pete.xml
+++ b/GM5/Sidekicks/Specific/Pickled Pete.xml
@@ -1,0 +1,1244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +6</skill>
+		<skill>Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Pete’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +6</skill>
+		<skill>Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +8</skill>
+		<skill>Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</npc>
+		<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +8</skill>
+		<skill>Persuasion +8</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15</skill>
+		<skill>Performance +10</skill>
+		<skill>Persuasion +10</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Pete is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Pete is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Pickled Pete</label>
+		<name>Pickled Pete 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>Pete has an uncanny knack for succeeding when they need to. If his attack misses a target within range, he can turn the miss into a hit. Alternatively, if he fail an ability check, he can treat the d20 roll as a 20.</text>
+			<text>Pete can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>Pete is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Pete is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Pete makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Pete is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Pete can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Pete can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Pete has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Pete’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Quinn Hightopple.xml
+++ b/GM5/Sidekicks/Specific/Quinn Hightopple.xml
@@ -1,0 +1,2259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+9|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack three times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Attacker)</label>
+		<name>Warrior (Attacker) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack four times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Quinn Hightopple (Defender)</label>
+		<name>Warrior (Defender) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Quinn’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Quinn has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Quinn can attack four times, instead of once, whenever he takes the attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Quinn’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Quinn imposes disadvantage on the attack roll of a creature within 5 feet of him whose target isn’t Quinn. Quinn must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Quinn Hightopple.xml
+++ b/GM5/Sidekicks/Specific/Quinn Hightopple.xml
@@ -4,26 +4,42 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 1</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>13/13 (2d8+4)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -32,32 +48,48 @@
 			<attack>2 hand|+6|1d10+2</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 1</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>13/13 (2d8+4)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -65,9 +97,9 @@
 			<attack>2 hand|+4|1d10+2</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -78,23 +110,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 2</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>19/19 (3d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Second Wind</name>
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
@@ -104,6 +136,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -111,36 +159,52 @@
 			<attack>2 hand|+6|1d10+2</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 2</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>19/19 (3d8 + 6)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Second Wind</name>
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -149,9 +213,9 @@
 			<attack>2 hand|+4|1d10+2</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -162,23 +226,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 3</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>26/26 (4d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -192,6 +256,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -199,32 +279,32 @@
 			<attack>2 hand|+6|1d10+2</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 3</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>26/26 (4d8 + 8)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>15</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +4</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -234,6 +314,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+3</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
@@ -241,9 +337,9 @@
 			<attack>2 hand|+4|1d10+2</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -254,23 +350,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 4</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>32/32 (5d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +5</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -284,6 +380,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -291,32 +403,32 @@
 			<attack>2 hand|+7|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+5|1d6+2</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 4</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>32/32 (5d8 + 10)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +4</save>
 		<skill>Athletics +5</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -326,6 +438,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+4</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -333,9 +461,9 @@
 			<attack>2 hand|+5|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+3|1d6+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -346,23 +474,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 5</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>39/39 (6d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -376,6 +504,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -383,32 +527,32 @@
 			<attack>2 hand|+8|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+6|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+6|1d6+2</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 5</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>39/39 (6d8 + 12)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Quinn’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -418,6 +562,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+5</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -425,9 +585,9 @@
 			<attack>2 hand|+6|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+4|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -438,23 +598,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 6</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>45/45 (7d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Extra Attack</name>
 			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
@@ -472,6 +632,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -479,32 +655,32 @@
 			<attack>2 hand|+8|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+6|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+6|1d6+2</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 6</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>16 (chain shirt, shield)</ac>
 		<hp>45/45 (7d8 + 14)</hp>
 		<speed>30 ft.</speed>
 		<init>1</init>
 		<str>17</str>
-		<dex>13</dex>
+		<dex>15</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Extra Attack</name>
 			<text>Quinn can attack twice, instead of once, whenever he takes the Attack action on his turn.</text>
@@ -518,6 +694,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+6</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -525,9 +717,9 @@
 			<attack>2 hand|+6|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+4|1d8+1</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.</text>
+			<attack>|+4|1d6+2</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -538,23 +730,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 7</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>20 (plate, shield)</ac>
 		<hp>52/52 (8d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Quinn has advantage on initiative rolls.</text>
@@ -576,6 +768,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -583,32 +791,32 @@
 			<attack>2 hand|+8|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+7|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 7</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>20 (plate, shield)</ac>
 		<hp>52/52 (8d8 + 16)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>16</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Quinn has advantage on initiative rolls.</text>
@@ -626,6 +834,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+7</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
@@ -633,9 +857,9 @@
 			<attack>2 hand|+6|1d10+3</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+5|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -646,23 +870,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 8</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>20 (plate, shield)</ac>
 		<hp>58/58 (9d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Quinn has advantage on initiative rolls.</text>
@@ -684,6 +908,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -691,32 +931,32 @@
 			<attack>2 hand|+9|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+7|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 8</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>20 (plate, shield)</ac>
 		<hp>58/58 (9d8 + 18)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Quinn has advantage on initiative rolls.</text>
@@ -734,6 +974,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+8</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -741,9 +997,9 @@
 			<attack>2 hand|+7|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+5|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -754,23 +1010,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 9</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>20 (plate, shield)</ac>
 		<hp>65/65 (10d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
@@ -796,6 +1052,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -803,32 +1075,32 @@
 			<attack>2 hand|+10|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 9</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>20 (plate, shield)</ac>
 		<hp>65/65 (10d8 + 20)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Quinn can reroll a saving throw that he fails but must use the new result.</text>
@@ -850,6 +1122,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+9</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -857,9 +1145,9 @@
 			<attack>2 hand|+8|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -870,23 +1158,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 10</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>71/71 (11d8 + 22)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -916,6 +1204,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -923,32 +1227,32 @@
 			<attack>2 hand|+10|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 10</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>71/71 (11d8 + 22)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -974,6 +1278,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+10</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -981,9 +1301,9 @@
 			<attack>2 hand|+8|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -994,23 +1314,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 11</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>78/78 (12d8 + 24)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1040,6 +1360,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -1047,32 +1383,32 @@
 			<attack>2 hand|+10|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 11</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>78/78 (12d8 + 24)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>18</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1098,6 +1434,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+11</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
@@ -1105,9 +1457,9 @@
 			<attack>2 hand|+8|1d10+4</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1118,23 +1470,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 12</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>84/84 (13d8 + 26)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1164,6 +1516,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1171,32 +1539,32 @@
 			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+8|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 12</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>84/84 (13d8 + 26)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1222,6 +1590,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+12</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1229,9 +1613,9 @@
 			<attack>2 hand|+9|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1244,23 +1628,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 13</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>91/91 (14d8+28)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1290,6 +1674,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1297,32 +1697,32 @@
 			<attack>2 hand|+12|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+9|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+9|1d6+3</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 13</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>91/91 (14d8+28)</hp>
 		<speed>30 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
+		<dex>16</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1348,6 +1748,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+13</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1355,9 +1771,9 @@
 			<attack>2 hand|+10|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+7|1d6+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1368,23 +1784,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 14</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>97/97 (15d8+30)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1414,6 +1830,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1421,32 +1853,32 @@
 			<attack>2 hand|+12|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+10|1d8+3</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+10|1d6+4</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 14</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>97/97 (15d8+30)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1472,6 +1904,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+14</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1479,9 +1927,9 @@
 			<attack>2 hand|+10|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+8|1d8+3</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1492,23 +1940,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 15</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>104/104 (16d8+32)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1538,6 +1986,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1545,32 +2009,32 @@
 			<attack>2 hand|+12|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+10|1d8+3</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+10|1d6+4</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 15</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>104/104 (16d8+32)</hp>
 		<speed>30 ft.</speed>
 		<init>3</init>
 		<str>20</str>
-		<dex>16</dex>
+		<dex>18</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1596,6 +2060,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+15</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1603,9 +2083,9 @@
 			<attack>2 hand|+10|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+8|1d8+3</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1616,23 +2096,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 16</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>110/110 (17d8+34)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1662,6 +2142,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1669,32 +2165,32 @@
 			<attack>2 hand|+12|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+11|1d8+4</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 16</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>110/110 (17d8+34)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +7</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1720,6 +2216,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. If he does so, he can’t use this feature again until he finishes a short or long rest.</text>
 			<roll>1d10+16</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1727,9 +2239,9 @@
 			<attack>2 hand|+10|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+9|1d8+4</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1740,23 +2252,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 17</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>117/117 (18d8+36)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1786,6 +2298,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1793,32 +2321,32 @@
 			<attack>2 hand|+13|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+12|1d8+4</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+12|1d6+5</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 17</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>117/117 (18d8+36)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Quinn’s AC increases by 1.</text>
@@ -1844,6 +2372,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+17</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1851,9 +2395,9 @@
 			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+10|1d8+4</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1864,23 +2408,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 18</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>123/123 (19d8+38)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
@@ -1914,6 +2458,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1921,32 +2481,32 @@
 			<attack>2 hand|+13|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+12|1d8+4</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+12|1d6+5</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 18</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
 		<hp>123/123 (19d8+38)</hp>
 		<speed>30 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
+		<dex>20</dex>
 		<con>14</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
@@ -1976,6 +2536,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+18</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -1983,9 +2559,9 @@
 			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+10|1d8+4</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1996,23 +2572,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 19</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>130/130 (20d8+40)</hp>
+		<hp>150/150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
@@ -2046,6 +2622,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -2053,32 +2645,32 @@
 			<attack>2 hand|+13|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
-			<attack>|+13|1d8+5</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+13|1d6+5</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 19</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>130/130 (20d8+40)</hp>
+		<hp>150/150 (20d8+60)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
@@ -2108,6 +2700,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+19</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -2115,9 +2723,9 @@
 			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
-			<attack>|+11|1d8+5</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -2128,23 +2736,23 @@
 		<label>Quinn Hightopple (Attacker)</label>
 		<name>Warrior (Attacker) 20</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>136/136 (21d8+42)</hp>
+		<hp>156/156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
@@ -2178,6 +2786,22 @@
 			<name>Martial Role: Attacker</name>
 			<text>Quinn gains a +2 bonus to attack rolls.</text>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -2185,32 +2809,32 @@
 			<attack>2 hand|+13|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
-			<attack>|+13|1d8+5</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+13|1d6+5</attack>
 		</action>
 	</npc>
 	<npc>
 		<label>Quinn Hightopple (Defender)</label>
 		<name>Warrior (Defender) 20</name>
 		<type>Humanoid</type>
-		<size>M</size>
+		<size>S</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>136/136 (21d8+42)</hp>
+		<hp>156/156 (21d8+62)</hp>
 		<speed>30 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
-		<cha>10</cha>
+		<cha>11</cha>
 		<save>Constitution +8</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Halfling</languages>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Quinn's total for a strength check is less than Quinn's strength score, the score can be used in place of the total.</text>
@@ -2240,6 +2864,22 @@
 			<text>Quinn can use a bonus action on his turn to regain hit points equal to 1d10 + his level. he can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+20</roll>
 		</trait>
+		<trait>
+			<name>Lucky</name>
+			<text>When Quinn rolls a 1 on an attack roll, ability check, or saving throw, he can reroll the die and must use the new roll.</text>
+		</trait>
+		<trait>
+			<name>Brave</name>
+			<text>Quinn have advantage on saving throws against being frightened.</text>
+		</trait>
+		<trait>
+			<name>Halfling Nimbleness</name>
+			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+		</trait>
+		<trait>
+			<name>Naturally Stealthy</name>
+			<text>Quinn can attempt to hide even when he is obscured only by a creature that is at least one size larger than him.</text>
+		</trait>
 		<action>
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
@@ -2247,9 +2887,9 @@
 			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
-			<attack>|+11|1d8+5</attack>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>

--- a/GM5/Sidekicks/Specific/Quinn Hightopple.xml
+++ b/GM5/Sidekicks/Specific/Quinn Hightopple.xml
@@ -35,7 +35,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -84,7 +84,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -146,7 +146,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -200,7 +200,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -266,7 +266,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -324,7 +324,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -390,7 +390,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -448,7 +448,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -514,7 +514,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -572,7 +572,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -642,7 +642,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -704,7 +704,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -778,7 +778,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -844,7 +844,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -918,7 +918,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -984,7 +984,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1062,7 +1062,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1132,7 +1132,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1214,7 +1214,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1288,7 +1288,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1370,7 +1370,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1444,7 +1444,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1526,7 +1526,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1600,7 +1600,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1684,7 +1684,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1758,7 +1758,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1840,7 +1840,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1914,7 +1914,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -1996,7 +1996,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2070,7 +2070,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2152,7 +2152,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2226,7 +2226,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2308,7 +2308,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2382,7 +2382,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2468,7 +2468,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2546,7 +2546,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2632,7 +2632,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2710,7 +2710,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2796,7 +2796,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>
@@ -2874,7 +2874,7 @@
 		</trait>
 		<trait>
 			<name>Halfling Nimbleness</name>
-			<text>Quinn can move through the space of any creature that is of a size larger than his.</text>
+			<text>Quinn can move through the space of any creature that is of a size larger than him.</text>
 		</trait>
 		<trait>
 			<name>Naturally Stealthy</name>

--- a/GM5/Sidekicks/Specific/Ruby Hammerwhacker.xml
+++ b/GM5/Sidekicks/Specific/Ruby Hammerwhacker.xml
@@ -1,0 +1,2259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>13/13 (2d8+4)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>19/19 (3d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+6|1d8+2</attack>
+			<attack>2 hand|+6|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>26/26 (4d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>15</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +4</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
+			<attack>|+4|1d8+2</attack>
+			<attack>2 hand|+4|1d10+2</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>32/32 (5d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +4</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>39/39 (6d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+5</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+6|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (7d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+6</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+4|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+8|1d8+3</attack>
+			<attack>2 hand|+8|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>52/52 (8d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>16</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+7</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+6|1d8+3</attack>
+			<attack>2 hand|+6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>58/58 (9d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +7</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>65/65 (10d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+9</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>71/71 (11d8 + 22)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+10</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+10|1d8+4</attack>
+			<attack>2 hand|+10|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>78/78 (12d8 + 24)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>18</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+11</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+8|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>84/84 (13d8 + 26)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +9</skill>
+		<skill>Perception +5</skill>
+		<skill>Survival +5</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (1/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+12</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+6|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+9|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>91/91 (14d8+28)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+13</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>97/97 (15d8+30)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>104/104 (16d8+32)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>16</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>110/110 (17d8+34)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>117/117 (18d8+36)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+17</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+12|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>123/123 (19d8+38)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+18</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+10|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>130/130 (20d8+40)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+19</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+13|1d8+5</attack>
+			<attack>2 hand|+13|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>136/136 (21d8+42)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>14</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +11</skill>
+		<skill>Perception +7</skill>
+		<skill>Survival +7</skill>
+		<passive>17</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Unstoppable Force</name>
+			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (3/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack four times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind (2 uses)</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
+			<roll>1d10+20</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Ruby Hammerwhacker.xml
+++ b/GM5/Sidekicks/Specific/Ruby Hammerwhacker.xml
@@ -6,279 +6,28 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>13/13 (2d8+4)</hp>
-		<speed>30 ft.</speed>
-		<init>1</init>
-		<str>15</str>
-		<dex>13</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +4</save>
-		<skill>Athletics +4</skill>
-		<skill>Perception +3</skill>
-		<skill>Survival +3</skill>
-		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
-			<attack>|+6|1d8+2</attack>
-			<attack>2 hand|+6|1d10+2</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
-		</action>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 1</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>16 (chain shirt, shield)</ac>
-		<hp>13/13 (2d8+4)</hp>
-		<speed>30 ft.</speed>
-		<init>1</init>
-		<str>15</str>
-		<dex>13</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +4</save>
-		<skill>Athletics +4</skill>
-		<skill>Perception +3</skill>
-		<skill>Survival +3</skill>
-		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
-			<attack>|+4|1d8+2</attack>
-			<attack>2 hand|+4|1d10+2</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
-		</action>
-		<reaction>
-			<name>Protection</name>
-			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
-		</reaction>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 2</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>16 (chain shirt, shield)</ac>
-		<hp>19/19 (3d8 + 6)</hp>
-		<speed>30 ft.</speed>
-		<init>1</init>
-		<str>15</str>
-		<dex>13</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +4</save>
-		<skill>Athletics +4</skill>
-		<skill>Perception +3</skill>
-		<skill>Survival +3</skill>
-		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+2</roll>
-		</trait>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
-			<attack>|+6|1d8+2</attack>
-			<attack>2 hand|+6|1d10+2</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
-		</action>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 2</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>16 (chain shirt, shield)</ac>
-		<hp>19/19 (3d8 + 6)</hp>
-		<speed>30 ft.</speed>
-		<init>1</init>
-		<str>15</str>
-		<dex>13</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +4</save>
-		<skill>Athletics +4</skill>
-		<skill>Perception +3</skill>
-		<skill>Survival +3</skill>
-		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+2</roll>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
-			<attack>|+4|1d8+2</attack>
-			<attack>2 hand|+4|1d10+2</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
-		</action>
-		<reaction>
-			<name>Protection</name>
-			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
-		</reaction>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 3</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>16 (chain shirt, shield)</ac>
-		<hp>26/26 (4d8 + 8)</hp>
-		<speed>30 ft.</speed>
-		<init>1</init>
-		<str>15</str>
-		<dex>13</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +4</save>
-		<skill>Athletics +4</skill>
-		<skill>Perception +3</skill>
-		<skill>Survival +3</skill>
-		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+3</roll>
-		</trait>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
-			<attack>|+6|1d8+2</attack>
-			<attack>2 hand|+6|1d10+2</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+5|1d8+1</attack>
-		</action>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 3</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>16 (chain shirt, shield)</ac>
-		<hp>26/26 (4d8 + 8)</hp>
-		<speed>30 ft.</speed>
-		<init>1</init>
-		<str>15</str>
-		<dex>13</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +4</save>
-		<skill>Athletics +4</skill>
-		<skill>Perception +3</skill>
-		<skill>Survival +3</skill>
-		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+3</roll>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d8 + 2 slashing damage.</text>
-			<attack>|+4|1d8+2</attack>
-			<attack>2 hand|+4|1d10+2</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
-			<attack>|+3|1d8+1</attack>
-		</action>
-		<reaction>
-			<name>Protection</name>
-			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
-		</reaction>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 4</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>16 (chain shirt, shield)</ac>
-		<hp>32/32 (5d8 + 10)</hp>
-		<speed>30 ft.</speed>
+		<hp>15/15 (2d8 + 6)</hp>
+		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
 		<dex>13</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +4</save>
+		<save>Constitution +5</save>
 		<skill>Athletics +5</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
 		</trait>
 		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+4</roll>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<trait>
 			<name>Martial Role: Attacker</name>
@@ -298,33 +47,32 @@
 	</npc>
 	<npc>
 		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 4</name>
+		<name>Warrior (Defender) 1</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>32/32 (5d8 + 10)</hp>
-		<speed>30 ft.</speed>
+		<hp>15/15 (2d8 + 6)</hp>
+		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
 		<dex>13</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +4</save>
+		<save>Constitution +5</save>
 		<skill>Athletics +5</skill>
 		<skill>Perception +3</skill>
 		<skill>Survival +3</skill>
 		<passive>13</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
 		</trait>
 		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+4</roll>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -344,25 +92,349 @@
 	</npc>
 	<npc>
 		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 5</name>
+		<name>Warrior (Attacker) 2</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>39/39 (6d8 + 12)</hp>
-		<speed>30 ft.</speed>
+		<hp>22/22 (3d8 + 9)</hp>
+		<speed>25 ft.</speed>
 		<init>1</init>
 		<str>17</str>
 		<dex>13</dex>
-		<con>14</con>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>22/22 (3d8 + 9)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>30/30 (4d8 + 12)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+7|1d8+3</attack>
+			<attack>2 hand|+7|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>30/30 (4d8 + 12)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>17</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +5</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+3</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
+			<attack>|+5|1d8+3</attack>
+			<attack>2 hand|+5|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>37/37 (5d8 + 15)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +5</save>
 		<skill>Athletics +6</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+8|1d8+4</attack>
+			<attack>2 hand|+8|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+5|1d8+1</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>37/37 (5d8 + 15)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +5</save>
+		<skill>Athletics +6</skill>
+		<skill>Perception +3</skill>
+		<skill>Survival +3</skill>
+		<passive>13</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+4</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+6|1d8+4</attack>
+			<attack>2 hand|+6|1d10+4</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.</text>
+			<attack>|+3|1d8+1</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (chain shirt, shield)</ac>
+		<hp>45/45 (6d8 + 18)</hp>
+		<speed>25 ft.</speed>
+		<init>1</init>
+		<str>19</str>
+		<dex>13</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -378,9 +450,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
-			<attack>|+8|1d8+3</attack>
-			<attack>2 hand|+8|1d10+3</attack>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -394,21 +466,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>39/39 (6d8 + 12)</hp>
-		<speed>30 ft.</speed>
+		<hp>45/45 (6d8 + 18)</hp>
+		<speed>25 ft.</speed>
 		<init>1</init>
-		<str>17</str>
+		<str>19</str>
 		<dex>13</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +5</save>
-		<skill>Athletics +6</skill>
+		<save>Constitution +6</save>
+		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
@@ -420,9 +500,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
-			<attack>|+6|1d8+3</attack>
-			<attack>2 hand|+6|1d10+3</attack>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -440,21 +520,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (7d8 + 14)</hp>
-		<speed>30 ft.</speed>
+		<hp>52/52 (7d8 + 21)</hp>
+		<speed>25 ft.</speed>
 		<init>1</init>
-		<str>17</str>
+		<str>19</str>
 		<dex>13</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +5</save>
-		<skill>Athletics +6</skill>
+		<save>Constitution +6</save>
+		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Extra Attack</name>
 			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
@@ -474,9 +562,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
-			<attack>|+8|1d8+3</attack>
-			<attack>2 hand|+8|1d10+3</attack>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+9|1d8+4</attack>
+			<attack>2 hand|+9|1d10+4</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -490,21 +578,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (chain shirt, shield)</ac>
-		<hp>45/45 (7d8 + 14)</hp>
-		<speed>30 ft.</speed>
+		<hp>52/52 (7d8 + 21)</hp>
+		<speed>25 ft.</speed>
 		<init>1</init>
-		<str>17</str>
+		<str>19</str>
 		<dex>13</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +5</save>
-		<skill>Athletics +6</skill>
+		<save>Constitution +6</save>
+		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Extra Attack</name>
 			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
@@ -520,9 +616,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
-			<attack>|+6|1d8+3</attack>
-			<attack>2 hand|+6|1d10+3</attack>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
+			<attack>|+7|1d8+4</attack>
+			<attack>2 hand|+7|1d10+4</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -540,129 +636,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>52/52 (8d8 + 16)</hp>
-		<speed>30 ft.</speed>
-		<init>2</init>
-		<str>16</str>
-		<dex>14</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +5</save>
-		<skill>Athletics +6</skill>
-		<skill>Perception +4</skill>
-		<skill>Survival +4</skill>
-		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Battle Readiness</name>
-			<text>Ruby has advantage on initiative rolls.</text>
-		</trait>
-		<trait>
-			<name>Extra Attack</name>
-			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
-		</trait>
-		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+7</roll>
-		</trait>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
-			<attack>|+8|1d8+3</attack>
-			<attack>2 hand|+8|1d10+3</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
-		</action>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 7</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>20 (plate, shield)</ac>
-		<hp>52/52 (8d8 + 16)</hp>
-		<speed>30 ft.</speed>
-		<init>2</init>
-		<str>16</str>
-		<dex>14</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +5</save>
-		<skill>Athletics +6</skill>
-		<skill>Perception +4</skill>
-		<skill>Survival +4</skill>
-		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Battle Readiness</name>
-			<text>Ruby has advantage on initiative rolls.</text>
-		</trait>
-		<trait>
-			<name>Extra Attack</name>
-			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
-		</trait>
-		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+7</roll>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1d8 + 3 slashing damage.</text>
-			<attack>|+6|1d8+3</attack>
-			<attack>2 hand|+6|1d10+3</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+5|1d8+2</attack>
-		</action>
-		<reaction>
-			<name>Protection</name>
-			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
-		</reaction>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 8</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>20 (plate, shield)</ac>
-		<hp>58/58 (9d8 + 18)</hp>
-		<speed>30 ft.</speed>
+		<hp>60/60 (8d8 + 24)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>18</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +5</save>
+		<save>Constitution +6</save>
 		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Ruby has advantage on initiative rolls.</text>
@@ -678,7 +674,7 @@
 		<trait>
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+8</roll>
+			<roll>1d10+7</roll>
 		</trait>
 		<trait>
 			<name>Martial Role: Attacker</name>
@@ -698,25 +694,33 @@
 	</npc>
 	<npc>
 		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 8</name>
+		<name>Warrior (Defender) 7</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>58/58 (9d8 + 18)</hp>
-		<speed>30 ft.</speed>
+		<hp>60/60 (8d8 + 24)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>18</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +5</save>
+		<save>Constitution +6</save>
 		<skill>Athletics +7</skill>
 		<skill>Perception +4</skill>
 		<skill>Survival +4</skill>
 		<passive>14</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Battle Readiness</name>
 			<text>Ruby has advantage on initiative rolls.</text>
@@ -732,7 +736,7 @@
 		<trait>
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+8</roll>
+			<roll>1d10+7</roll>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -752,25 +756,157 @@
 	</npc>
 	<npc>
 		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 9</name>
+		<name>Warrior (Attacker) 8</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>65/65 (10d8 + 20)</hp>
-		<speed>30 ft.</speed>
+		<hp>67/67 (9d8 + 27)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
-		<str>18</str>
+		<str>20</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
 		<save>Constitution +6</save>
 		<skill>Athletics +8</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+7|1d8+2</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>67/67 (9d8 + 27)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +6</save>
+		<skill>Athletics +8</skill>
+		<skill>Perception +4</skill>
+		<skill>Survival +4</skill>
+		<passive>14</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+8</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+8|1d8+5</attack>
+			<attack>2 hand|+8|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
+			<attack>|+5|1d8+2</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>20 (plate, shield)</ac>
+		<hp>75/75 (10d8 + 30)</hp>
+		<speed>25 ft.</speed>
+		<init>2</init>
+		<str>20</str>
+		<dex>14</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +7</save>
+		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
@@ -798,9 +934,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
-			<attack>|+10|1d8+4</attack>
-			<attack>2 hand|+10|1d10+4</attack>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -814,21 +950,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>20 (plate, shield)</ac>
-		<hp>65/65 (10d8 + 20)</hp>
-		<speed>30 ft.</speed>
+		<hp>75/75 (10d8 + 30)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
-		<str>18</str>
+		<str>20</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
-		<skill>Athletics +8</skill>
+		<save>Constitution +7</save>
+		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
@@ -852,9 +996,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
-			<attack>|+8|1d8+4</attack>
-			<attack>2 hand|+8|1d10+4</attack>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -872,21 +1016,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>71/71 (11d8 + 22)</hp>
-		<speed>30 ft.</speed>
+		<hp>82/82 (11d8 + 33)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
-		<str>18</str>
+		<str>20</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
-		<skill>Athletics +8</skill>
+		<save>Constitution +7</save>
+		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -918,9 +1070,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
-			<attack>|+10|1d8+4</attack>
-			<attack>2 hand|+10|1d10+4</attack>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -934,21 +1086,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>71/71 (11d8 + 22)</hp>
-		<speed>30 ft.</speed>
+		<hp>82/82 (11d8 + 33)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
-		<str>18</str>
+		<str>20</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
-		<skill>Athletics +8</skill>
+		<save>Constitution +7</save>
+		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -976,9 +1136,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
-			<attack>|+8|1d8+4</attack>
-			<attack>2 hand|+8|1d10+4</attack>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -996,21 +1156,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>78/78 (12d8 + 24)</hp>
-		<speed>30 ft.</speed>
+		<hp>90/90 (12d8 + 36)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
-		<str>18</str>
+		<str>20</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
-		<skill>Athletics +8</skill>
+		<save>Constitution +7</save>
+		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1042,9 +1210,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
-			<attack>|+10|1d8+4</attack>
-			<attack>2 hand|+10|1d10+4</attack>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+11|1d8+5</attack>
+			<attack>2 hand|+11|1d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -1058,21 +1226,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>78/78 (12d8 + 24)</hp>
-		<speed>30 ft.</speed>
+		<hp>90/90 (12d8 + 36)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
-		<str>18</str>
+		<str>20</str>
 		<dex>14</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
-		<skill>Athletics +8</skill>
+		<save>Constitution +7</save>
+		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1100,9 +1276,9 @@
 		</trait>
 		<action>
 			<name>Longsword</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 1d8 + 4 slashing damage.</text>
-			<attack>|+8|1d8+4</attack>
-			<attack>2 hand|+8|1d10+4</attack>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+9|1d8+5</attack>
+			<attack>2 hand|+9|1d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
@@ -1120,21 +1296,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>84/84 (13d8 + 26)</hp>
-		<speed>30 ft.</speed>
+		<hp>97/97 (13d8 + 39)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
-		<con>14</con>
+		<dex>16</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
+		<save>Constitution +7</save>
 		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1172,8 +1356,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+8|1d8+2</attack>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+9|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1182,21 +1366,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>84/84 (13d8 + 26)</hp>
-		<speed>30 ft.</speed>
+		<hp>97/97 (13d8 + 39)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
-		<con>14</con>
+		<dex>16</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +6</save>
+		<save>Constitution +7</save>
 		<skill>Athletics +9</skill>
 		<skill>Perception +5</skill>
 		<skill>Survival +5</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1226,12 +1418,12 @@
 			<name>Longsword</name>
 			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
 			<attack>|+9|1d8+5</attack>
-			<attack>2 hand|+9|1d10+5</attack>
+			<attack>2 hand|+8|2d10+5</attack>
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+6|1d8+2</attack>
+			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+7|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1246,21 +1438,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>91/91 (14d8+28)</hp>
-		<speed>30 ft.</speed>
+		<hp>105/105 (14d8 + 42)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
-		<con>14</con>
+		<dex>16</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +7</save>
+		<save>Constitution +8</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1298,8 +1498,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+9|1d8+2</attack>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+10|1d8+3</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1308,21 +1508,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>91/91 (14d8+28)</hp>
-		<speed>30 ft.</speed>
+		<hp>105/105 (14d8 + 42)</hp>
+		<speed>25 ft.</speed>
 		<init>2</init>
 		<str>20</str>
-		<dex>14</dex>
-		<con>14</con>
+		<dex>16</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +7</save>
+		<save>Constitution +8</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>15</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1356,8 +1564,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.</text>
-			<attack>|+7|1d8+2</attack>
+			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
+			<attack>|+8|1d8+3</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1370,269 +1578,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (15d8+30)</hp>
-		<speed>30 ft.</speed>
+		<hp>112/112 (15d8 + 45)</hp>
+		<speed>25 ft.</speed>
 		<init>3</init>
-		<str>20</str>
-		<dex>16</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +7</save>
-		<skill>Athletics +10</skill>
-		<skill>Perception +6</skill>
-		<skill>Survival +6</skill>
-		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Improved Defense</name>
-			<text>Ruby’s AC increases by 1.</text>
-		</trait>
-		<trait>
-			<name>Indomitable (2/Day)</name>
-			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
-		</trait>
-		<trait>
-			<name>Battle Readiness</name>
-			<text>Ruby has advantage on initiative rolls.</text>
-		</trait>
-		<trait>
-			<name>Extra Attack</name>
-			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
-		</trait>
-		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+14</roll>
-		</trait>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
-			<attack>|+12|1d8+5</attack>
-			<attack>2 hand|+12|1d10+5</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+10|1d8+3</attack>
-		</action>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 14</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>21 (plate, shield)</ac>
-		<hp>97/97 (15d8+30)</hp>
-		<speed>30 ft.</speed>
-		<init>3</init>
-		<str>20</str>
-		<dex>16</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +7</save>
-		<skill>Athletics +10</skill>
-		<skill>Perception +6</skill>
-		<skill>Survival +6</skill>
-		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Improved Defense</name>
-			<text>Ruby’s AC increases by 1.</text>
-		</trait>
-		<trait>
-			<name>Indomitable (2/Day)</name>
-			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
-		</trait>
-		<trait>
-			<name>Battle Readiness</name>
-			<text>Ruby has advantage on initiative rolls.</text>
-		</trait>
-		<trait>
-			<name>Extra Attack</name>
-			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
-		</trait>
-		<trait>
-			<name>Improved Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+14</roll>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
-			<attack>|+10|1d8+5</attack>
-			<attack>2 hand|+10|1d10+5</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+8|1d8+3</attack>
-		</action>
-		<reaction>
-			<name>Protection</name>
-			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
-		</reaction>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 15</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>21 (plate, shield)</ac>
-		<hp>104/104 (16d8+32)</hp>
-		<speed>30 ft.</speed>
-		<init>3</init>
-		<str>20</str>
-		<dex>16</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +7</save>
-		<skill>Athletics +10</skill>
-		<skill>Perception +6</skill>
-		<skill>Survival +6</skill>
-		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Improved Defense</name>
-			<text>Ruby’s AC increases by 1.</text>
-		</trait>
-		<trait>
-			<name>Indomitable (2/Day)</name>
-			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
-		</trait>
-		<trait>
-			<name>Battle Readiness</name>
-			<text>Ruby has advantage on initiative rolls.</text>
-		</trait>
-		<trait>
-			<name>Extra Attack</name>
-			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
-		</trait>
-		<trait>
-			<name>Superior Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+15</roll>
-		</trait>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
-			<attack>|+12|1d8+5</attack>
-			<attack>2 hand|+12|1d10+5</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+10|1d8+3</attack>
-		</action>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 15</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>21 (plate, shield)</ac>
-		<hp>104/104 (16d8+32)</hp>
-		<speed>30 ft.</speed>
-		<init>3</init>
-		<str>20</str>
-		<dex>16</dex>
-		<con>14</con>
-		<int>10</int>
-		<wis>12</wis>
-		<cha>10</cha>
-		<save>Constitution +7</save>
-		<skill>Athletics +10</skill>
-		<skill>Perception +6</skill>
-		<skill>Survival +6</skill>
-		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
-		<trait>
-			<name>Improved Defense</name>
-			<text>Ruby’s AC increases by 1.</text>
-		</trait>
-		<trait>
-			<name>Indomitable (2/Day)</name>
-			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
-		</trait>
-		<trait>
-			<name>Battle Readiness</name>
-			<text>Ruby has advantage on initiative rolls.</text>
-		</trait>
-		<trait>
-			<name>Extra Attack</name>
-			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
-		</trait>
-		<trait>
-			<name>Superior Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+15</roll>
-		</trait>
-		<action>
-			<name>Longsword</name>
-			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
-			<attack>|+10|1d8+5</attack>
-			<attack>2 hand|+10|1d10+5</attack>
-		</action>
-		<action>
-			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +8 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage.</text>
-			<attack>|+8|1d8+3</attack>
-		</action>
-		<reaction>
-			<name>Protection</name>
-			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
-		</reaction>
-	</npc>
-	<npc>
-		<label>Ruby Hammerwhacker (Attacker)</label>
-		<name>Warrior (Attacker) 16</name>
-		<type>Humanoid</type>
-		<size>M</size>
-		<ac>21 (plate, shield)</ac>
-		<hp>110/110 (17d8+34)</hp>
-		<speed>30 ft.</speed>
-		<init>4</init>
 		<str>20</str>
 		<dex>18</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +7</save>
+		<save>Constitution +8</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1650,13 +1618,13 @@
 			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
 		</trait>
 		<trait>
-			<name>Superior Critical</name>
-			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
 		<trait>
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+16</roll>
+			<roll>1d10+14</roll>
 		</trait>
 		<trait>
 			<name>Martial Role: Attacker</name>
@@ -1676,25 +1644,313 @@
 	</npc>
 	<npc>
 		<label>Ruby Hammerwhacker (Defender)</label>
-		<name>Warrior (Defender) 16</name>
+		<name>Warrior (Defender) 14</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>110/110 (17d8+34)</hp>
-		<speed>30 ft.</speed>
-		<init>4</init>
+		<hp>112/112 (15d8 + 45)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
 		<str>20</str>
 		<dex>18</dex>
-		<con>14</con>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +7</save>
+		<save>Constitution +8</save>
 		<skill>Athletics +10</skill>
 		<skill>Perception +6</skill>
 		<skill>Survival +6</skill>
 		<passive>16</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Improved Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+14</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>120/120 (16d8 + 48)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+11|1d8+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>120/120 (16d8 + 48)</hp>
+		<speed>25 ft.</speed>
+		<init>3</init>
+		<str>20</str>
+		<dex>18</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+15</roll>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+10|1d8+5</attack>
+			<attack>2 hand|+10|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
+			<attack>|+9|1d8+4</attack>
+		</action>
+		<reaction>
+			<name>Protection</name>
+			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
+		</reaction>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Attacker)</label>
+		<name>Warrior (Attacker) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>127/127 (17d8 + 51)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
+		<trait>
+			<name>Improved Defense</name>
+			<text>Ruby’s AC increases by 1.</text>
+		</trait>
+		<trait>
+			<name>Indomitable (2/Day)</name>
+			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
+		</trait>
+		<trait>
+			<name>Battle Readiness</name>
+			<text>Ruby has advantage on initiative rolls.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Ruby can attack three times, instead of once, whenever she takes the attack action on her turn.</text>
+		</trait>
+		<trait>
+			<name>Superior Critical</name>
+			<text>Ruby’s attack rolls now score a critical hit on a roll of 18-20 on the d20.</text>
+		</trait>
+		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 1d8 + 5 slashing damage.</text>
+			<attack>|+12|1d8+5</attack>
+			<attack>2 hand|+12|1d10+5</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+12|1d8+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Ruby Hammerwhacker (Defender)</label>
+		<name>Warrior (Defender) 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>21 (plate, shield)</ac>
+		<hp>127/127 (17d8 + 51)</hp>
+		<speed>25 ft.</speed>
+		<init>4</init>
+		<str>20</str>
+		<dex>20</dex>
+		<con>16</con>
+		<int>10</int>
+		<wis>12</wis>
+		<cha>10</cha>
+		<save>Constitution +8</save>
+		<skill>Athletics +10</skill>
+		<skill>Perception +6</skill>
+		<skill>Survival +6</skill>
+		<passive>16</passive>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1728,8 +1984,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +9 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+9|1d8+4</attack>
+			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+10|1d8+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1742,21 +1998,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>117/117 (18d8+36)</hp>
-		<speed>30 ft.</speed>
+		<hp>135/135 (18d8 + 54)</hp>
+		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
-		<con>14</con>
+		<dex>20</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +9</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1794,8 +2058,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+12|1d8+4</attack>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1804,21 +2068,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>117/117 (18d8+36)</hp>
-		<speed>30 ft.</speed>
+		<hp>135/135 (18d8 + 54)</hp>
+		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
-		<con>14</con>
+		<dex>20</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +9</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
@@ -1852,8 +2124,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+10|1d8+4</attack>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
@@ -1866,21 +2138,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>123/123 (19d8+38)</hp>
-		<speed>30 ft.</speed>
+		<hp>142/142 (19d8 + 57)</hp>
+		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
-		<con>14</con>
+		<dex>20</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +9</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
@@ -1922,8 +2202,8 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +12 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+12|1d8+4</attack>
+			<text>Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+13|1d8+5</attack>
 		</action>
 	</npc>
 	<npc>
@@ -1932,21 +2212,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>123/123 (19d8+38)</hp>
-		<speed>30 ft.</speed>
+		<hp>142/142 (19d8 + 57)</hp>
+		<speed>25 ft.</speed>
 		<init>4</init>
 		<str>20</str>
-		<dex>18</dex>
-		<con>14</con>
+		<dex>20</dex>
+		<con>16</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +9</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
@@ -1984,35 +2272,43 @@
 		</action>
 		<action>
 			<name>Longbow</name>
-			<text>Ranged Weapon Attack: +10 to hit, range 150/600 ft., one target. Hit: 8 (1d8 + 4) piercing damage.</text>
-			<attack>|+10|1d8+4</attack>
+			<text>Ranged Weapon Attack: +11 to hit, range 150/600 ft., one target. Hit: 9 (1d8 + 5) piercing damage.</text>
+			<attack>|+11|1d8+5</attack>
 		</action>
 		<reaction>
 			<name>Protection</name>
 			<text>Ruby imposes disadvantage on the attack roll of a creature within 5 feet of her whose target isn’t Ruby. Ruby must be able to see the attacker.</text>
 		</reaction>
 	</npc>
-	<npc>
+		<npc>
 		<label>Ruby Hammerwhacker (Attacker)</label>
 		<name>Warrior (Attacker) 19</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>130/130 (20d8+40)</hp>
-		<speed>30 ft.</speed>
+		<hp>170/170 (20d8 + 80)</hp>
+		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>18</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +10</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
@@ -2064,21 +2360,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>130/130 (20d8+40)</hp>
-		<speed>30 ft.</speed>
+		<hp>170/170 (20d8 + 80)</hp>
+		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>18</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +10</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
@@ -2130,21 +2434,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>136/136 (21d8+42)</hp>
-		<speed>30 ft.</speed>
+		<hp>178/178 (21d8 + 84)</hp>
+		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>18</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +10</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
@@ -2196,21 +2508,29 @@
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>21 (plate, shield)</ac>
-		<hp>136/136 (21d8+42)</hp>
-		<speed>30 ft.</speed>
+		<hp>178/178 (21d8 + 84)</hp>
+		<speed>25 ft.</speed>
 		<init>5</init>
 		<str>20</str>
 		<dex>20</dex>
-		<con>14</con>
+		<con>18</con>
 		<int>10</int>
 		<wis>12</wis>
 		<cha>10</cha>
-		<save>Constitution +8</save>
+		<save>Constitution +10</save>
 		<skill>Athletics +11</skill>
 		<skill>Perception +7</skill>
 		<skill>Survival +7</skill>
 		<passive>17</passive>
-		<languages>Common, plus one of your choice</languages>
+		<languages>Common, Dwarvish</languages>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
+		</trait>
 		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>

--- a/GM5/Sidekicks/Specific/Ruby Hammerwhacker.xml
+++ b/GM5/Sidekicks/Specific/Ruby Hammerwhacker.xml
@@ -22,16 +22,16 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
+			<name>Martial Role: Attacker</name>
+			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
 			<name>Darkvision</name>
 			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
 		</trait>
 		<trait>
 			<name>Dwarven Resilience</name>
 			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
-			<name>Martial Role: Attacker</name>
-			<text>Ruby gains a +2 bonus to attack rolls.</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -112,14 +112,6 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+2</roll>
@@ -127,6 +119,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -162,17 +162,17 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
+			<name>Second Wind</name>
+			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
+			<roll>1d10+2</roll>
+		</trait>
+		<trait>
 			<name>Darkvision</name>
 			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
 		</trait>
 		<trait>
 			<name>Dwarven Resilience</name>
 			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
-			<name>Second Wind</name>
-			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
-			<roll>1d10+2</roll>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -212,14 +212,6 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
@@ -231,6 +223,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -266,14 +266,6 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
@@ -281,6 +273,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+3</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -320,14 +320,6 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
@@ -339,6 +331,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -374,14 +374,6 @@
 		<passive>13</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
@@ -389,6 +381,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+4</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -428,14 +428,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
@@ -447,6 +439,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -482,14 +482,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Critical</name>
 			<text>Ruby’s attack rolls now score a critical hit on a roll of 19 or 20 on the d20.</text>
 		</trait>
@@ -497,6 +489,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+5</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -536,14 +536,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Extra Attack</name>
 			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
 		</trait>
@@ -559,6 +551,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -594,14 +594,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Extra Attack</name>
 			<text>Ruby can attack twice, instead of once, whenever she takes the Attack action on her turn.</text>
 		</trait>
@@ -613,6 +605,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+6</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -652,14 +652,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Battle Readiness</name>
 			<text>Ruby has advantage on initiative rolls.</text>
 		</trait>
@@ -679,6 +671,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -714,14 +714,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Battle Readiness</name>
 			<text>Ruby has advantage on initiative rolls.</text>
 		</trait>
@@ -737,6 +729,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+7</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -776,14 +776,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Battle Readiness</name>
 			<text>Ruby has advantage on initiative rolls.</text>
 		</trait>
@@ -803,6 +795,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -838,14 +838,6 @@
 		<passive>14</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Battle Readiness</name>
 			<text>Ruby has advantage on initiative rolls.</text>
 		</trait>
@@ -861,6 +853,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+8</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -900,14 +900,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
 		</trait>
@@ -931,6 +923,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -966,14 +966,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Indomitable (1/Day)</name>
 			<text>Ruby can reroll a saving throw that she fails but must use the new result.</text>
 		</trait>
@@ -993,6 +985,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+9</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1032,14 +1032,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1067,6 +1059,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1102,14 +1102,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1133,6 +1125,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+10</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1172,14 +1172,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1207,6 +1199,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1242,14 +1242,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1273,6 +1265,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+11</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1312,14 +1312,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1347,6 +1339,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1382,14 +1382,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1413,6 +1405,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+12</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1454,14 +1454,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1489,6 +1481,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1524,14 +1524,6 @@
 		<passive>15</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1555,6 +1547,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+13</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1594,14 +1594,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1629,6 +1621,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1664,14 +1664,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1695,6 +1687,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+14</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1734,14 +1734,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1769,6 +1761,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1804,14 +1804,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1835,6 +1827,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+15</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1874,14 +1874,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1909,6 +1901,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -1944,14 +1944,6 @@
 		<passive>16</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -1975,6 +1967,14 @@
 			<name>Second Wind</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. If she does so, she can’t use this feature again until she finishes a short or long rest.</text>
 			<roll>1d10+16</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2014,14 +2014,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -2049,6 +2041,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2084,14 +2084,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Improved Defense</name>
 			<text>Ruby’s AC increases by 1.</text>
 		</trait>
@@ -2115,6 +2107,14 @@
 			<name>Second Wind (2 uses)</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+17</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2154,14 +2154,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
 		</trait>
@@ -2193,6 +2185,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2228,14 +2228,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
 		</trait>
@@ -2263,6 +2255,14 @@
 			<name>Second Wind (2 uses)</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+18</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2302,14 +2302,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
 		</trait>
@@ -2341,6 +2333,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2376,14 +2376,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
 		</trait>
@@ -2411,6 +2403,14 @@
 			<name>Second Wind (2 uses)</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+19</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2450,14 +2450,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
 		</trait>
@@ -2489,6 +2481,14 @@
 		<trait>
 			<name>Martial Role: Attacker</name>
 			<text>Ruby gains a +2 bonus to attack rolls.</text>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>
@@ -2524,14 +2524,6 @@
 		<passive>17</passive>
 		<languages>Common, Dwarvish</languages>
 		<trait>
-			<name>Darkvision</name>
-			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
-		</trait>
-		<trait>
-			<name>Dwarven Resilience</name>
-			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
-		</trait>
-		<trait>
 			<name>Unstoppable Force</name>
 			<text>If Ruby's total for a strength check is less than Ruby's strength score, the score can be used in place of the total.</text>
 		</trait>
@@ -2559,6 +2551,14 @@
 			<name>Second Wind (2 uses)</name>
 			<text>Ruby can use a bonus action on her turn to regain hit points equal to 1d10 + her level. she can use this feature twice before needing to finish a short or long rest.</text>
 			<roll>1d10+20</roll>
+		</trait>
+		<trait>
+			<name>Darkvision</name>
+			<text>Accustomed to life underground, Ruby have superior vision in dark and dim conditions. She can see in dim light within 60 feet of her as if it were bright light, and in darkness as if it were dim light. She can’t discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Resilience</name>
+			<text>Ruby has advantage on saving throws against poison and resistance to poison damage</text>
 		</trait>
 		<action>
 			<name>Longsword</name>

--- a/GM5/Sidekicks/Specific/Shajan Kwan (Mage).xml
+++ b/GM5/Sidekicks/Specific/Shajan Kwan (Mage).xml
@@ -1,0 +1,1081 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 1</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +4</skill>
+		<skill>Investigation +4</skill>
+		<skill>Religion +4</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 12, +4 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 2</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (2 slots): sleep, burning hands</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 3</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 4</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (3 slots): sleep, burning hands, shield</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 5</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 6</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>18</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (2 slots): invisibility</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 7</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>17</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (1 slot): wall of fire</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 8</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 9</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (1 slot): cone of cold</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (2 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>19</int>
+		<wis>15</wis>
+		<cha>15</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>15</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +10</skill>
+		<skill>Investigation +10</skill>
+		<skill>Religion +10</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>15</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (2 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>15</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +11</skill>
+		<skill>Investigation +11</skill>
+		<skill>Religion +11</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (1 slot): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (1 slot): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +12</skill>
+		<skill>Investigation +12</skill>
+		<skill>Religion +12</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Shajan Kwan (Mage)</label>
+		<name>Shajan Kwan (Mage) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>11</con>
+		<int>20</int>
+		<wis>16</wis>
+		<cha>15</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +12</skill>
+		<skill>Investigation +12</skill>
+		<skill>Religion +12</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Shajan can choose one 3rd level spell. Shajan can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Intelligence (spell save DC 19, +11 to hit with spell attacks). Shajan has following wizard spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): fire bolt, light, mage hand, minor illusion, shocking grasp</text>
+			<text></text>
+			<text>1st level (4 slots): sleep, burning hands, shield</text>
+			<text></text>
+			<text>2nd level (3 slots): invisibility, flaming sphere</text>
+			<text></text>
+			<text>3rd level (3 slots): fireball, fly</text>
+			<text></text>
+			<text>4th level (3 slots): wall of fire, polymorph</text>
+			<text></text>
+			<text>5th level (3 slots): cone of cold, hold monster, telekinesis</text>
+			<text></text>
+			<text>6th level (2 slots): chain lightning, circle of death, circle of death</text>
+			<text></text>
+			<text>7th level (2 slots): delayed blast fireball, finger of death</text>
+			<text></text>
+			<text>8th level (1 slot): incendiary cloud, dominate monster</text>
+			<text></text>
+			<text>9th level (1 slot): meteor swarm, power word kill</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Fire Bolt, Light, Sleep, Burning Hands, Shield, Mage Hand, Invisibility, Minor Illusion, Flaming Sphere, Fireball, Fly, Wall of Fire, Polymorph, Cone of Cold, Shocking Grasp, Hold Monster, Chain Lightning, Delayed Blast Fireball, Telekinesis, Incendiary Cloud, Circle of Death, Meteor Swarm, Finger of Death, Dominate Monster, Power Word Kill</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Shajan Kwan (Mage).xml
+++ b/GM5/Sidekicks/Specific/Shajan Kwan (Mage).xml
@@ -3,7 +3,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 1</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>9/9 (2d8)</hp>
@@ -41,7 +41,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 2</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>13/13 (3d8)</hp>
@@ -79,7 +79,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 3</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>18/18 (4d8)</hp>
@@ -117,7 +117,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 4</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>22/22 (5d8)</hp>
@@ -155,7 +155,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 5</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>27/27 (6d8)</hp>
@@ -195,7 +195,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 6</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>31/31 (7d8)</hp>
@@ -239,7 +239,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 7</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>36/36 (8d8)</hp>
@@ -287,7 +287,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 8</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>40/40 (9d8)</hp>
@@ -335,7 +335,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 9</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>45/45 (10d8)</hp>
@@ -385,7 +385,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>49/49 (11d8)</hp>
@@ -439,7 +439,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>54/54 (12d8)</hp>
@@ -495,7 +495,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>58/58 (13d8)</hp>
@@ -553,7 +553,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>63/63 (14d8)</hp>
@@ -611,7 +611,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>67/67 (15d8)</hp>
@@ -673,7 +673,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>72/72 (16d8)</hp>
@@ -737,7 +737,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
@@ -801,7 +801,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
@@ -867,7 +867,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
@@ -937,7 +937,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
@@ -1007,7 +1007,7 @@
 	<npc>
 		<label>Shajan Kwan (Mage)</label>
 		<name>Shajan Kwan (Mage) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>

--- a/GM5/Sidekicks/Specific/Shanjan Kwan (Healer).xml
+++ b/GM5/Sidekicks/Specific/Shanjan Kwan (Healer).xml
@@ -3,7 +3,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 1</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>9/9 (2d8)</hp>
@@ -41,7 +41,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 2</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>13/13 (3d8)</hp>
@@ -79,7 +79,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 3</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>18/18 (4d8)</hp>
@@ -117,7 +117,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 4</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>22/22 (5d8)</hp>
@@ -155,7 +155,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 5</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>27/27 (6d8)</hp>
@@ -195,7 +195,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 6</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
 		<hp>31/31 (7d8)</hp>
@@ -239,7 +239,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 7</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>36/36 (8d8)</hp>
@@ -287,7 +287,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 8</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>40/40 (9d8)</hp>
@@ -335,7 +335,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 9</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>45/45 (10d8)</hp>
@@ -385,7 +385,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 10</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>49/49 (11d8)</hp>
@@ -439,7 +439,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 11</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
 		<hp>54/54 (12d8)</hp>
@@ -495,7 +495,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 12</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>58/58 (13d8)</hp>
@@ -553,7 +553,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 13</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>63/63 (14d8)</hp>
@@ -611,7 +611,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 14</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>67/67 (15d8)</hp>
@@ -673,7 +673,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 15</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
 		<hp>72/72 (16d8)</hp>
@@ -737,7 +737,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 16</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>76/76 (17d8)</hp>
@@ -801,7 +801,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 17</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>81/81 (18d8)</hp>
@@ -867,7 +867,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 18</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
 		<hp>85/85 (19d8)</hp>
@@ -937,7 +937,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 19</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
 		<hp>90/90 (20d8)</hp>
@@ -1007,7 +1007,7 @@
 	<npc>
 		<label>Spellcaster (Healer)</label>
 		<name>Spellcaster (Healer) 20</name>
-		<type>humanoid, sidekick</type>
+		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
 		<hp>94/94 (21d8)</hp>

--- a/GM5/Sidekicks/Specific/Shanjan Kwan (Healer).xml
+++ b/GM5/Sidekicks/Specific/Shanjan Kwan (Healer).xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <characters version="5">
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 1</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 1</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
@@ -39,8 +39,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 2</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 2</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
@@ -77,8 +77,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 3</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 3</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
@@ -115,8 +115,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 4</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 4</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
@@ -153,8 +153,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 5</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 5</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
@@ -193,8 +193,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 6</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 6</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>12 (leather)</ac>
@@ -237,8 +237,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 7</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 7</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
@@ -285,8 +285,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 8</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 8</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
@@ -333,8 +333,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 9</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 9</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
@@ -383,8 +383,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 10</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 10</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
@@ -437,8 +437,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 11</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 11</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>13 (studded leather)</ac>
@@ -493,8 +493,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 12</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 12</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
@@ -551,8 +551,8 @@
 
 	<!--Extrapolated Leveling-->
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 13</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 13</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
@@ -609,8 +609,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 14</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 14</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
@@ -671,8 +671,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 15</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 15</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>14 (studded leather)</ac>
@@ -735,8 +735,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 16</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 16</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
@@ -799,8 +799,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 17</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 17</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
@@ -865,8 +865,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 18</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 18</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>15 (studded leather)</ac>
@@ -935,8 +935,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 19</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 19</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>
@@ -1005,8 +1005,8 @@
 		</action>
 	</npc>
 	<npc>
-		<label>Spellcaster (Healer)</label>
-		<name>Spellcaster (Healer) 20</name>
+		<label>Shajan Kwan (Healer)</label>
+		<name>Shajan Kwan (Healer) 20</name>
 		<type>Humanoid</type>
 		<size>M</size>
 		<ac>16 (studded leather)</ac>

--- a/GM5/Sidekicks/Specific/Shanjan Kwan (Healer).xml
+++ b/GM5/Sidekicks/Specific/Shanjan Kwan (Healer).xml
@@ -1,0 +1,1081 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 1</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>9/9 (2d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 2</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>13/13 (3d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (2 slots): cure wounds, bless</text>
+		</trait>
+		<slots>2,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 3</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>18/18 (4d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>15</wis>
+		<cha>14</cha>
+		<save>Wisdom +4</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>12</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 4</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>22/22 (5d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +5</save>
+		<skill>Arcana +5</skill>
+		<skill>Investigation +5</skill>
+		<skill>Religion +5</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (3 slots): cure wounds, bless, shield of faith</text>
+		</trait>
+		<slots>3,0,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+2|1d6</attack>
+			<attack>2 hand|+2|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 5</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>27/27 (6d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 6</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>12 (leather)</ac>
+		<hp>31/31 (7d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (2 slots): aid</text>
+		</trait>
+		<slots>4,2,0,0,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 7</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>36/36 (8d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>17</wis>
+		<cha>14</cha>
+		<save>Wisdom +6</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>13</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (1 slot): death ward</text>
+		</trait>
+		<slots>4,3,3,1,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 8</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>40/40 (9d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +7</save>
+		<skill>Arcana +6</skill>
+		<skill>Investigation +6</skill>
+		<skill>Religion +6</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+		</trait>
+		<slots>4,3,3,2,0,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+3|1d6</attack>
+			<attack>2 hand|+3|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 9</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>45/45 (10d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (1 slot): greater restoration</text>
+		</trait>
+		<slots>4,3,3,3,1,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 10</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>49/49 (11d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (2 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+		</trait>
+		<slots>4,3,3,3,2,0,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 11</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>13 (studded leather)</ac>
+		<hp>54/54 (12d8)</hp>
+		<speed>30 ft.</speed>
+		<init>1</init>
+		<str>11</str>
+		<dex>13</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>19</wis>
+		<cha>14</cha>
+		<save>Wisdom +8</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>14</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 12</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>58/58 (13d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +9</save>
+		<skill>Arcana +7</skill>
+		<skill>Investigation +7</skill>
+		<skill>Religion +7</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,0,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+4|1d6</attack>
+			<attack>2 hand|+4|1d8</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 13</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>63/63 (14d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 14</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>67/67 (15d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,0,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 15</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>14 (studded leather)</ac>
+		<hp>72/72 (16d8)</hp>
+		<speed>30 ft.</speed>
+		<init>2</init>
+		<str>11</str>
+		<dex>14</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 16</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>76/76 (17d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +10</save>
+		<skill>Arcana +8</skill>
+		<skill>Investigation +8</skill>
+		<skill>Religion +8</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,0,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+5|1d6</attack>
+			<attack>2 hand|+5|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 17</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>81/81 (18d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (2 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,2,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 18</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>85/85 (19d8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (1 slot): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (1 slot): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,1,1,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 19</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>90/90 (20d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Spellcaster (Healer)</label>
+		<name>Spellcaster (Healer) 20</name>
+		<type>humanoid, sidekick</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>94/94 (21d8)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>11</con>
+		<int>16</int>
+		<wis>20</wis>
+		<cha>14</cha>
+		<save>Wisdom +11</save>
+		<skill>Arcana +9</skill>
+		<skill>Investigation +9</skill>
+		<skill>Religion +9</skill>
+		<passive>15</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Signature Spell</name>
+			<text>Shajan can choose one 3rd level spell. Shajan can cast this spell once without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Spell Mastery</name>
+			<text>Shajan has such mastery over certain spells that they can cast them at will. Choose a 1st-level spell and a 2nd-level spell that are Shajan knows. Shajan can cast those spells twice at their lowest level without expending a spell slot.</text>
+		</trait>
+		<trait>
+			<name>Overchannel</name>
+			<text>Shajan can increase the power of their simpler spells. When Shajan casts a spell of 5th level or lower that deals damage or heals, Shajan can deal maximum damage/healing with that spell once per day.</text>
+		</trait>
+		<trait>
+			<name>Empowered Spells</name>
+			<text>Choose one school of magic. Whenever Shajan casts a spell of that school by expending a spell slot, Shajan can add its spellcasting ability modifier to the spell’s damage roll or healing roll, if any.</text>
+		</trait>
+		<trait>
+			<name>Potent Cantrips</name>
+			<text>Shajan can add its spellcasting ability modifier to the damage it deals with any cantrip.</text>
+		</trait>
+		<trait>
+			<name>Spellcasting</name>
+			<text>Shajan’s spellcasting ability is Wisdom (spell save DC 19, +11 to hit with spell attacks). Shajan has following cleric spells prepared:</text>
+			<text></text>
+			<text>Cantrips (at will): guidance, sacred flame, resistance, light, spare the dying</text>
+			<text></text>
+			<text>1st level (4 slots): cure wounds, bless, shield of faith</text>
+			<text></text>
+			<text>2nd level (3 slots): aid, lesser restoration</text>
+			<text></text>
+			<text>3rd level (3 slots): protection from energy, revivify</text>
+			<text></text>
+			<text>4th level (3 slots): death ward, banishment</text>
+			<text></text>
+			<text>5th level (3 slots): greater restoration, mass cure wounds, dispel evil and good</text>
+			<text></text>
+			<text>6th level (2 slots): heal, heroes' feast</text>
+			<text></text>
+			<text>7th level (2 slots): regenerate, resurrection</text>
+			<text></text>
+			<text>8th level (1 slot): holy aura, antimagic field</text>
+			<text></text>
+			<text>9th level (1 slot): mass heal, true resurrection</text>
+		</trait>
+		<slots>4,3,3,3,3,2,2,1,1,</slots>
+		<spells>Guidance, Sacred Flame, Cure Wounds, Bless, Shield of Faith, Resistance, Aid, Light, Lesser Restoration, Protection from Energy, Revivify, Death Ward, Banishment, Greater Restoration, Spare the Dying, Mass Cure Wounds, Heal, Regenerate, Dispel Evil and Good, Holy Aura, Heroes' Feast, Mass Heal, Resurrection, Antimagic Field, True Resurrection</spells>
+		<action>
+			<name>Quarterstaff</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 4 (1d8) bludgeoning damage if used with two hands.</text>
+			<attack>|+6|1d6</attack>
+			<attack>2 hand|+6|1d8</attack>
+		</action>
+	</npc>
+</characters>

--- a/GM5/Sidekicks/Specific/Talon Thornwild.xml
+++ b/GM5/Sidekicks/Specific/Talon Thornwild.xml
@@ -1,0 +1,1244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<characters version="5">
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 1</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>11/11 (2d8 + 2)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 2</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>16/16 (3d8 + 3)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 3</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>22/22 (4d8 + 4)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>16</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +5</save>
+		<skill>Acrobatics +5</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +5</skill>
+		<skill>Stealth +5</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+5|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+5|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 4</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>27/27 (5d8 + 5)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +6</skill>
+		<skill>Performance +4</skill>
+		<skill>Persuasion +4</skill>
+		<skill>Sleight of Hand +6</skill>
+		<skill>Stealth +6</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+6|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+6|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 5</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>33/33 (6d8 + 6)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 6</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>38/38 (7d8 + 7)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>18</dex>
+		<con>13</con>
+		<int>14</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +7</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +7</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Expertise</name>
+			<text>Choose two of Talon’s skill proficiencies. The proficiency bonus is doubled for any ability check he makes that uses either of the chosen proficiencies.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 7</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>15 (studded leather)</ac>
+		<hp>44/44 (8d8 + 8)</hp>
+		<speed>30 ft.</speed>
+		<init>3</init>
+		<str>11</str>
+		<dex>17</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +6</save>
+		<skill>Acrobatics +9</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +6</skill>
+		<skill>Stealth +9</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.</text>
+			<attack>|+6|1d4+3</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.</text>
+			<attack>|+6|1d6+3</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 8</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>49/49 (9d8 + 9)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +7</save>
+		<skill>Acrobatics +10</skill>
+		<skill>Performance +5</skill>
+		<skill>Persuasion +5</skill>
+		<skill>Sleight of Hand +7</skill>
+		<skill>Stealth +10</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 4) piercing damage.</text>
+			<attack>|+7|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +7 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+7|1d6+4</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 9</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>16 (studded leather)</ac>
+		<hp>55/55 (10d8 + 10)</hp>
+		<speed>30 ft.</speed>
+		<init>4</init>
+		<str>11</str>
+		<dex>19</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>15</cha>
+		<save>Dexterity +8</save>
+		<skill>Acrobatics +12</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +8</skill>
+		<skill>Stealth +12</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 (1d4 + 4) piercing damage.</text>
+			<attack>|+8|1d4+4</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +8 to hit, range 80/320 ft., one target. Hit: 7 (1d6 + 4) piercing damage.</text>
+			<attack>|+8|1d6+4</attack>
+		</action>
+	</npc>
+		<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 10</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>60/60 (11d8 + 11)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 11</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>66/66 (12d8 + 12)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>16</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +6</skill>
+		<skill>Persuasion +6</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 12</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>71/71 (13d8 + 13)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +9</save>
+		<skill>Acrobatics +13</skill>
+		<skill>Performance +8</skill>
+		<skill>Persuasion +8</skill>
+		<skill>Sleight of Hand +9</skill>
+		<skill>Stealth +13</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +9 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+9|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +9 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+9|1d6+5</attack>
+		</action>
+	</npc>
+
+	<!--Extrapolated Leveling-->
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 13</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>77/77 (14d8 + 14)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 14</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>82/82 (15d8 + 15)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 15</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>88/88 (16d8 + 16)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>18</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +16</skill>
+		<skill>Performance +9</skill>
+		<skill>Persuasion +9</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 16</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>93/93 (17d8 + 17)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +10</save>
+		<save>Wisdom +5</save>
+		<skill>Acrobatics +15</skill>
+		<skill>Performance +10</skill>
+		<skill>Persuasion +10</skill>
+		<skill>Sleight of Hand +10</skill>
+		<skill>Stealth +15</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +10 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+10|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +10 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+10|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 17</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>99/99 (18d8 + 18)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 18</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>104/104 (19d8 + 19)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>11</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +6</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>10</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Talon is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 19</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>110/110 (20d8 + 20)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Elusive</name>
+			<text>Talon is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+	<npc>
+		<label>Talon Thornwild</label>
+		<name>Talon Thornwild 20</name>
+		<type>Humanoid</type>
+		<size>M</size>
+		<ac>17 (studded leather)</ac>
+		<hp>115/115 (21d8 + 21)</hp>
+		<speed>30 ft.</speed>
+		<init>5</init>
+		<str>11</str>
+		<dex>20</dex>
+		<con>13</con>
+		<int>15</int>
+		<wis>13</wis>
+		<cha>20</cha>
+		<save>Dexterity +11</save>
+		<save>Wisdom +7</save>
+		<skill>Acrobatics +17</skill>
+		<skill>Performance +11</skill>
+		<skill>Persuasion +11</skill>
+		<skill>Sleight of Hand +11</skill>
+		<skill>Stealth +17</skill>
+		<passive>11</passive>
+		<languages>Common, plus one of your choice</languages>
+		<trait>
+			<name>Stroke of Luck</name>
+			<text>Talon has an uncanny knack for succeeding when they need to. If his attack misses a target within range, he can turn the miss into a hit. Alternatively, if he fail an ability check, he can treat the d20 roll as a 20.</text>
+			<text>Talon can use this ability once per day.</text>
+		</trait>
+		<trait>
+			<name>Elusive</name>
+			<text>Talon is so evasive that attackers rarely gain the upper hand against him. No attack roll has advantage against him while they aren't incapacitated.</text>
+		</trait>
+		<trait>
+			<name>Blindsense</name>
+			<text>If Talon is able to hear, he is aware of the location of any hidden or invisible creature within 10 feet of him.</text>
+		</trait>
+		<trait>
+			<name>Reliable Talent</name>
+			<text>Whenever Talon makes an ability check that includes his whole proficiency bonus, it can treat a d20 roll of 9 or lower as a 10.</text>
+		</trait>
+		<trait>
+			<name>Evasion</name>
+			<text>When Talon is not incapacitated and subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, he instead takes no damage if he succeeds on the saving throw, and only half damage if he failed.</text>
+		</trait>
+		<trait>
+			<name>Extra Attack</name>
+			<text>Talon can attack twice, instead of once, whenever it takes the Attack action on his turn.</text>
+		</trait>
+		<trait>
+			<name>Helpful</name>
+			<text>Talon can take the Help action as a bonus action, and the creature who receives the help gains a 1d6 bonus to the d20 roll. If that roll is an attack roll, the creature can forgo adding the bonus to it, and then if the attack hits, the creature can add the bonus to the attack’s damage roll against one target.</text>
+		</trait>
+		<trait>
+			<name>Tools</name>
+			<text>Talon has thieves’ tools and a musical instrument.</text>
+		</trait>
+		<trait>
+			<name>Cunning Action</name>
+			<text>On Talon’s turn in combat, he can take the Dash, Disengage, or Hide action as a bonus action.</text>
+		</trait>
+		<action>
+			<name>Shortsword</name>
+			<text>Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+		<action>
+			<name>Dagger</name>
+			<text>Melee or Ranged Weapon Attack: +11 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 (1d4 + 5) piercing damage.</text>
+			<attack>|+11|1d4+5</attack>
+		</action>
+		<action>
+			<name>Shortbow</name>
+			<text>Ranged Weapon Attack: +11 to hit, range 80/320 ft., one target. Hit: 8 (1d6 + 5) piercing damage.</text>
+			<attack>|+11|1d6+5</attack>
+		</action>
+	</npc>
+</characters>


### PR DESCRIPTION
- added additional dragon of icespire peak monsters
- added Claugiyliamatar to storm king's thunder
- fixed passive tag for greater zombie
- added more additional dragon of icespire peak monsters
- added remainder of icespire peak monsters
- fixed tag indentation
- added Lhammaruntosz as a dragon of icespire peak monster
- added warrior with extrapolated levels
- Added expert up to lvl 12
- Added specific warriors without racial changes
- Removed expertise trait from expert > lvl 6, since it has already been added
- Added spellcaster sidkicks up to lvl 12
- added racial traits/bonuses for Ruby
- Moved racial traits to bottom of list
- added racial traits for Inverna
- added racial traits for Quinn
- added extrapolated expert levels
- Extrapolated leveling for spellcaster
- Added sidekicks to bestiary
- Fixed spellcaster AC
- Added Donnabella as specific spellcaster
- Added specific experts
- Fixed Quinn's Halfling nibleness wording
- Added Nib Addlespur as a specific spellcaster
- Added Shajan Kwan as specific spellcaster
- Fixed non monster sidekick types to Humanoid
- Fixed Shajan Kwan sidekick npc name
- Added sidekicks as monsters for bestiary/reference
- fixed hp, added races and base racial traits
